### PR TITLE
Admin Redirect & Priority State Issues

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -83,8 +83,7 @@ export async function GET(request: NextRequest) {
         status: partner.status || "inactive",
         hasSubscription: !!partner.subscription_details,
       });
-      const redirectPath = partner.subscription_details ? "/admin-v2" : "/admin";
-      return NextResponse.redirect(new URL(redirectPath, request.url));
+      return NextResponse.redirect(new URL("/admin-v2", request.url));
     }
 
     // For signup context: redirect back to get-started with email

--- a/src/app/partnerlogin/page.tsx
+++ b/src/app/partnerlogin/page.tsx
@@ -25,7 +25,7 @@ export default function PartnerLoginPage() {
     try {
       await signInPartnerWithEmail(partnerData.email, partnerData.password);
       await Notification.token.save();
-      navigate.push("/admin");
+      navigate.push("/admin-v2");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to sign in");
     } finally {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1710,7 +1710,7 @@ export default function ProfilePage() {
       <div className="max-w-4xl mx-auto space-y-6">
         {/* Back Button */}
         <Button
-          onClick={() => router.push("/admin")}
+          onClick={() => router.push("/admin-v2")}
           variant="ghost"
           className="flex items-center gap-2 hover:bg-orange-100 text-gray-700"
         >

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -56,7 +56,7 @@ const BottomNav = () => {
       case "partner":
         const partnerItems = [
           {
-            href: "/admin",
+            href: "/admin-v2",
             name: "Dashboard",
             icon: <LayoutDashboard size={20} />,
             exactMatch: true,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -439,7 +439,7 @@ export function Navbar() {
     const adminLinks = [
       ...(userData?.role === "partner"
         ? [
-            { href: "/admin", label: "Admin" },
+            { href: "/admin-v2", label: "Admin" },
             ...((features?.ordering.access || features?.delivery.access) &&
             userData.status === "active"
               ? [{ href: "/admin/orders", label: "Orders" }]

--- a/src/components/PartnerDialog.tsx
+++ b/src/components/PartnerDialog.tsx
@@ -130,7 +130,7 @@ export function PartnerDialog() {
       toast.success("Account created successfully!");
       localStorage?.removeItem("partnerFormData");
       setTimeout(() => {
-        router.push("/admin");
+        router.push("/admin-v2");
       }, 1000);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "An unexpected error occurred";

--- a/src/providers/AuthInitializer.tsx
+++ b/src/providers/AuthInitializer.tsx
@@ -17,11 +17,7 @@ const AuthInitializer = () => {
     if (!loading && userData?.role === "partner") {
       const restrictedPaths = ["/", "/explore"];
       if (restrictedPaths.includes(pathname)) {
-        if ((userData as any).subscription_details) {
-          router.push("/admin-v2");
-        } else {
-          router.push("/admin");
-        }
+        router.push("/admin-v2");
       }
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -153,10 +153,9 @@ export async function proxy(request: NextRequest) {
         return NextResponse.redirect(new URL("/superadmin", request.url));
       }
 
-      // Partner redirects to /admin or /admin-v2 based on subscription
+      // Partner always redirects to /admin-v2
       if (decrypted?.role === "partner") {
-        const redirectPath = decrypted?.hasSubscription ? "/admin-v2" : "/admin";
-        return NextResponse.redirect(new URL(redirectPath, request.url));
+        return NextResponse.redirect(new URL("/admin-v2", request.url));
       }
 
       // User stays on home page
@@ -307,8 +306,8 @@ export async function proxy(request: NextRequest) {
 
     const userRole = decrypted.role as keyof typeof roleAccessRules;
 
-    if (userRole === "partner" && pathname === "/admin" && country !== "IN") {
-      return NextResponse.rewrite(new URL("/admin", request.url), {
+    if (userRole === "partner" && (pathname === "/admin" || pathname === "/admin-v2") && country !== "IN") {
+      return NextResponse.rewrite(new URL("/admin-v2", request.url), {
         request: {
           headers: requestHeaders,
         },
@@ -327,11 +326,11 @@ export async function proxy(request: NextRequest) {
         pathname.startsWith("/admin/") ||
         (pathname === "/admin" && !isAllowedRoute)
       ) {
-        return NextResponse.redirect(new URL("/admin", request.url));
+        return NextResponse.redirect(new URL("/admin-v2", request.url));
       }
 
       if (!isAllowedRoute) {
-        return NextResponse.redirect(new URL("/admin", request.url));
+        return NextResponse.redirect(new URL("/admin-v2", request.url));
       }
     } else {
       // Normal role-based access check for active users

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -104,17 +104,13 @@ export default function Login() {
     e.preventDefault();
     setIsLoading(true);
     try {
-      const partner = await signInPartnerWithEmail(
+      await signInPartnerWithEmail(
         partnerData.email,
         partnerData.password,
       );
       await Notification.token.save();
 
-      if (partner && partner.subscription_details) {
-        navigate.push("/admin-v2");
-      } else {
-        navigate.push("/admin");
-      }
+      navigate.push("/admin-v2");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to sign in");
       console.error("Sign in error:", error);


### PR DESCRIPTION
## Summary
- Replace all `/admin` redirects and navigation links with `/admin-v2` for partner-roled users across the entire codebase
- Remove conditional subscription-based redirect logic (previously `/admin` for no subscription, `/admin-v2` for subscription) — partners now always go to `/admin-v2`
- Update middleware (proxy.ts) to redirect partners to `/admin-v2` on root path, inactive state, and non-IN country flows
- Update sign-in flows: Login page, partner login, Google OAuth callback, partner signup, and AuthInitializer
- Update navigation links in BottomNav and Navbar to point partners to `/admin-v2`
- Update profile page back button to navigate to `/admin-v2`

**Files changed:** 9 files across login flows, middleware, navigation components, and auth callbacks

## Test plan
- [ ] Partner login (email/password) redirects to `/admin-v2`
- [ ] Partner login (Google OAuth) redirects to `/admin-v2`
- [ ] Partner signup redirects to `/admin-v2`
- [ ] Visiting `/` as a logged-in partner redirects to `/admin-v2`
- [ ] Inactive partner gets redirected to `/admin-v2` (not `/admin`)
- [ ] Non-IN country partner gets rewritten to `/admin-v2`
- [ ] Account switching in admin-v2 stays on `/admin-v2`
- [ ] Sign out from admin-v2 goes to `/login`
- [ ] Profile page back button navigates to `/admin-v2`
- [ ] BottomNav dashboard link points to `/admin-v2`
- [ ] Old `/admin` page still auto-redirects to `/admin-v2` (existing safety net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)