### PR TITLE
Loyalty points: partner-scoped earn & redeem with a signed tamper-proof ledger

### DIFF
--- a/feature_readme/SECURITY-admin-secret-migration.md
+++ b/feature_readme/SECURITY-admin-secret-migration.md
@@ -1,0 +1,61 @@
+# Security hardening — staged migration off browser-exposed secrets
+
+Surfaced while building loyalty points. Two app-wide weaknesses let a determined user
+tamper with data or impersonate accounts. The loyalty ledger is already safe against
+both (signed, server-only). These fixes harden **the rest of the app** and should each
+land as their own reviewed PR — they are intentionally **not** bundled into the loyalty
+change because they are cross-cutting and one of them logs every user out.
+
+---
+
+## Weakness 1 — Hasura admin secret is shipped to the browser
+
+`src/lib/hasuraClient.ts` reads `NEXT_PUBLIC_HASURA_GRAPHQL_ADMIN_SECRET`, so the
+god-mode secret is in the client bundle. Anyone can extract it and read/write **any**
+table directly, bypassing all permissions.
+
+**Target:** the browser talks to Hasura as a scoped role (`user` / `partner` / `anonymous`)
+via a short-lived JWT; the admin secret lives only on the server.
+
+**Staged plan**
+1. **Server client (done).** `src/lib/hasuraServerClient.ts` uses the server-only
+   `HASURA_SERVER_ADMIN_SECRET`. New privileged code (loyalty) already uses it.
+2. **JWT mode.** Configure `HASURA_GRAPHQL_JWT_SECRET` on Hasura. On login, mint a JWT
+   with `x-hasura-user-id` / `x-hasura-default-role` / `x-hasura-allowed-roles`. Hasura
+   accepts admin-secret **and** JWT during the transition, so nothing breaks yet.
+3. **Define permissions per table/role.** The loyalty tables already ship the reference
+   pattern (`user`: select rows where `user_id = X-Hasura-User-Id`; `partner`: by
+   `X-Hasura-Partner-Id`; no client writes). Work table-by-table: select first, then
+   insert/update/delete, mirroring what the client actually does.
+4. **Switch the client** from `x-hasura-admin-secret` to `Authorization: Bearer <jwt>`.
+   Move any genuinely-privileged client calls to server actions (like loyalty).
+5. **Remove `NEXT_PUBLIC_HASURA_GRAPHQL_ADMIN_SECRET`** once every query is covered and
+   verified. This is the step that closes the hole; do it last, behind a full QA pass.
+
+Rough order by surface: orders → menu/offers → partner CRUD → analytics/misc.
+
+---
+
+## Weakness 2 — Auth cookie is encrypted with a browser-exposed key
+
+`src/lib/encrtption.ts` encrypts the `new_auth_token` cookie with
+`NEXT_PUBLIC_ENCRYPTION_KEY`. The cookie is httpOnly (client JS can't read it), but
+because the AES key is in the bundle, an attacker can **mint a valid cookie for any
+user id** and impersonate them — which would let them spend that user's loyalty points
+(and do anything else that trusts `getAuthCookie`).
+
+**Fix**
+1. Introduce a **server-only** `AUTH_ENCRYPTION_KEY` (no `NEXT_PUBLIC_`). Confirm
+   `encryptText`/`decryptText` are only called from server code (`src/app/auth/actions.ts`)
+   — they are today.
+2. Switch encryption to the server-only key. **Do not** keep the public key as a decrypt
+   fallback — that would leave the forgery path open.
+3. Consequence: existing sessions can't be decrypted → **every user is logged out once**
+   and signs back in. Schedule accordingly (off-peak, with a heads-up).
+4. Optional: switch to a signed (HMAC/JWT) session token so tampering is detectable
+   rather than relying on encryption secrecy.
+
+Until this lands, loyalty redemption is exactly as forgeable as every other
+cookie-trusting server action in the app (e.g. order cancellation) — no worse, but the
+signed ledger means a forger could spend a victim's points yet still cannot *inflate*
+or *mint* points.

--- a/feature_readme/loyalty-points.md
+++ b/feature_readme/loyalty-points.md
@@ -1,0 +1,157 @@
+# Loyalty Points
+
+Partner-scoped customer loyalty. A customer earns a configurable % of every
+**completed** order's total as points, and can redeem those points against future
+orders **at the same partner only**. Points are non-transferable and tamper-evident.
+
+> Money model (locked): **1 point = ₹1** (`point_value`, configurable internally).
+> Default earn rate **2%**. A ₹500 completed order → 10 points → ₹10 off next time.
+
+---
+
+## Feature flag
+
+`loyalty_points` in `src/lib/getFeatures.ts` (stored in `partners.feature_flags` as
+`loyalty_points-true|false`, same comma-separated convention as every other flag).
+
+- **access** — superadmin grants it (add `loyalty_points-false` to the partner's
+  `feature_flags`). Once present, the partner sees the toggle + settings.
+- **enabled** — the partner turns it on under **Settings → Features**. Gates earning,
+  the checkout redeem UI, and the admin Loyalty surfaces.
+
+## Settings (`partners.loyalty_settings`, JSON string)
+
+Configured under **Settings → Loyalty** (`LoyaltyPointsSettings.tsx`). Shape +
+defaults live in `src/lib/loyalty/config.ts`:
+
+| field | default | meaning |
+|---|---|---|
+| `earn_percent` | 2 | % of order total earned on completion |
+| `min_order_amount` | 0 | minimum order total (₹) to earn |
+| `max_redeem_percent` | 100 | max % of a bill payable with points |
+| `min_redeem_points` | 1 | minimum points to redeem on an order |
+| `point_value` | 1 | ₹ per point (kept at 1) |
+
+---
+
+## Data model (`neon db` source)
+
+- **`loyalty_accounts`** — one row per `(user_id, partner_id)`. Holds the cached
+  `balance`, `lifetime_earned`, `lifetime_redeemed`, and the chain head
+  (`last_seq`, `last_hash`, `last_txn_id`). `UNIQUE(user_id, partner_id)`.
+- **`loyalty_transactions`** — append-only, **HMAC-signed, hash-chained** ledger.
+  Types: `earn`, `redeem`, `refund`, `adjust_credit`, `adjust_debit`. Each row stores
+  a signed `delta`, the running `balance_after`, a per-account `seq`, `prev_hash`, and
+  `hash`. `UNIQUE(account_id, seq)` serializes writes; a partial
+  `UNIQUE(order_id, type)` makes earn/redeem/refund idempotent per order.
+- **`orders`** gains `loyalty_points_redeemed`, `loyalty_redeem_value`,
+  `loyalty_points_earned` (display + idempotency snapshots).
+
+Migration: `hasura/migrations/neon db/1780200000000_create_loyalty_points/`. Table
+metadata + role permissions: `public_loyalty_accounts.yaml`,
+`public_loyalty_transactions.yaml`. **Already applied to the live `neon db`.**
+
+---
+
+## Security model — why points can't be tampered or transferred
+
+The Hasura admin secret is currently shipped to the browser
+(`NEXT_PUBLIC_HASURA_GRAPHQL_ADMIN_SECRET`), and there are no row-level Hasura
+permissions, so *anyone who extracts that secret can write any table directly*. The
+loyalty ledger is therefore designed to be safe **even against an attacker who holds
+the admin secret**:
+
+1. **Signed, chained ledger.** Every row is `HMAC-SHA256`-signed with
+   `LOYALTY_LEDGER_SECRET` — a **server-only** key (no `NEXT_PUBLIC_` prefix, never in
+   the browser bundle) — over `(id, account, user, partner, order, type, delta,
+   balance_after, seq, prev_hash)`, and chained to the previous row via `prev_hash`.
+   - Forging or editing a row requires the secret → **balances can't be inflated**.
+   - There is no "transfer" operation, and a valid earn for user A can't be minted for
+     user B → **points are non-transferable**.
+   - Deleting/reordering rows breaks the chain and is detected; at worst it *reduces* a
+     balance (a denial), never increases one.
+2. **Server-only writes.** All mutations go through `src/app/actions/loyalty.ts`
+   ("use server") using `src/lib/hasuraServerClient.ts` (the server-only secret). The
+   client never writes loyalty tables.
+3. **Verify-before-spend.** Before any redeem/adjust, the cached balance is checked
+   against the signed head (`verifyHead`); a mismatch **flags the account**
+   (`flagged_at`) and blocks further writes. `verifyChain` is the full audit.
+4. **Identity** comes from the encrypted httpOnly auth cookie (`getAuthCookie`), the
+   same trust basis as every other server action in this app.
+
+Verified live: `append → chain-verify → balance fold → idempotency → tamper detection
+→ concurrency` all pass (see the integrity test referenced in the PR).
+
+### ⚠️ Root-cause follow-up (begin the migration)
+
+`loyalty_points` is safe today, but two app-wide weaknesses remain and should be fixed
+in their own staged passes (see `feature_readme/SECURITY-admin-secret-migration.md`):
+
+1. The browser-exposed admin secret (forward-looking `user`/`partner` SELECT
+   permissions are already defined on the loyalty tables as the reference pattern).
+2. The auth cookie is AES-encrypted with a **browser-exposed** key
+   (`NEXT_PUBLIC_ENCRYPTION_KEY`), so the identity cookie is theoretically forgeable.
+   This was **not** silently changed here because re-keying logs every user out.
+
+---
+
+## Flows
+
+### Earn (on completion)
+`updateOrderStatus(...,'completed')` in `orderStore.ts` and `posStore.ts` fire
+`awardLoyaltyForOrder(orderId)` (fire-and-forget). It re-reads the real order
+server-side, self-gates on the partner's flag, computes points from `total_price`, and
+writes one signed `earn` (idempotent on `order_id`). Optional bulletproof backstop:
+a Hasura event trigger → `POST /api/loyalty/award` (see below).
+
+### Redeem (at checkout)
+`PlaceOrderModal` shows `LoyaltyRedeemCard` (balance + slider, capped by
+`max_redeem_percent`). The order is created at its pre-redeem total, then
+`redeemLoyaltyPoints({orderId, points})`:
+- reads the order as the authoritative base total (never trusts a client amount),
+- re-validates the balance + caps, writes the signed `redeem`,
+- **corrects** `orders.total_price` and returns the amount to charge.
+
+COD applies the correction directly. Online (Cashfree) redeems **before** locking the
+charge, so the customer is charged the post-redemption total.
+
+### Refund (compensating credit)
+If a redeemed order fails, a signed `refund` is appended (idempotent):
+- online payment fail → in `PlaceOrderModal`; abandoned/expired → `expireCfOrder`;
+- cancellation → `cancelOrderAction`.
+
+---
+
+## Surfaces
+
+- **Admin → Loyalty** (`AdminV2Loyalty.tsx`, sidebar, feature-gated): summary
+  (members, outstanding liability, lifetime issued/redeemed), searchable member list,
+  per-customer history + **manual grant/deduct** (`adminAdjustLoyalty`, signed).
+- **Admin → order detail** (`OrderDetails.tsx`): "Loyalty Points Redeemed (N pts) −₹X",
+  "Balance Payable", and points earned.
+- **Customer → checkout**: redeem card + "View history".
+- **Customer → order page** (`OrderClient.tsx`): redeemed line, "You earned N points",
+  and a tappable points badge → bottom-sheet history (`LoyaltyPointsBadge` /
+  `LoyaltyHistorySheet`).
+
+---
+
+## Deployment — REQUIRED env vars
+
+Add to every server environment (e.g. Vercel). The loyalty server actions throw
+without them:
+
+```
+HASURA_SERVER_ADMIN_SECRET=<prod Hasura admin secret>   # server-only (NO NEXT_PUBLIC_)
+LOYALTY_LEDGER_SECRET=<random 32-byte hex>              # server-only; permanent (rotating
+                                                        # invalidates existing signatures)
+```
+
+(`HASURA_SERVER_GRAPHQL_ENDPOINT` is optional; it falls back to the public endpoint URL,
+which isn't a secret.) `.env` already has them locally — generate a fresh
+`LOYALTY_LEDGER_SECRET` per environment with `openssl rand -hex 32`.
+
+### Optional: Hasura event trigger (most robust earn)
+The in-app hooks cover every UI completion path. For a DB-level backstop, add a Hasura
+event trigger on `orders` UPDATE → `POST https://<app>/api/loyalty/award` with header
+`Authorization: Bearer <CRON_SECRET>`. The route is idempotent and self-gating.

--- a/feature_readme/loyalty-points.md
+++ b/feature_readme/loyalty-points.md
@@ -148,8 +148,15 @@ LOYALTY_LEDGER_SECRET=<random 32-byte hex>              # server-only; permanent
 ```
 
 (`HASURA_SERVER_GRAPHQL_ENDPOINT` is optional; it falls back to the public endpoint URL,
-which isn't a secret.) `.env` already has them locally — generate a fresh
-`LOYALTY_LEDGER_SECRET` per environment with `openssl rand -hex 32`.
+which isn't a secret.) `.env` already has both locally.
+
+> **Use the SAME `LOYALTY_LEDGER_SECRET` in every environment that touches the shared
+> production ledger** (Vercel prod, local dev, previews). The secret is the HMAC key for
+> the ledger signatures, so a different value in another environment would make rows
+> signed elsewhere fail verification. Copy the exact value from `.env` — do NOT generate
+> a new one per environment. (Only a genuinely separate database, e.g. an isolated
+> staging DB, would get its own key.) `HASURA_SERVER_ADMIN_SECRET` is simply your
+> existing Hasura admin secret under a non-public name.
 
 ### Optional: Hasura event trigger (most robust earn)
 The in-app hooks cover every UI completion path. For a DB-level backstop, add a Hasura

--- a/hasura/metadata/databases/neon db/tables/public_loyalty_accounts.yaml
+++ b/hasura/metadata/databases/neon db/tables/public_loyalty_accounts.yaml
@@ -1,0 +1,31 @@
+table:
+  name: loyalty_accounts
+  schema: public
+object_relationships:
+  - name: partner
+    using:
+      foreign_key_constraint_on: partner_id
+  - name: user
+    using:
+      foreign_key_constraint_on: user_id
+array_relationships:
+  - name: transactions
+    using:
+      foreign_key_constraint_on:
+        column: account_id
+        table:
+          name: loyalty_transactions
+          schema: public
+select_permissions:
+  - role: partner
+    permission:
+      columns: '*'
+      filter:
+        partner_id:
+          _eq: X-Hasura-Partner-Id
+  - role: user
+    permission:
+      columns: '*'
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id

--- a/hasura/metadata/databases/neon db/tables/public_loyalty_transactions.yaml
+++ b/hasura/metadata/databases/neon db/tables/public_loyalty_transactions.yaml
@@ -1,0 +1,29 @@
+table:
+  name: loyalty_transactions
+  schema: public
+object_relationships:
+  - name: account
+    using:
+      foreign_key_constraint_on: account_id
+  - name: order
+    using:
+      foreign_key_constraint_on: order_id
+  - name: partner
+    using:
+      foreign_key_constraint_on: partner_id
+  - name: user
+    using:
+      foreign_key_constraint_on: user_id
+select_permissions:
+  - role: partner
+    permission:
+      columns: '*'
+      filter:
+        partner_id:
+          _eq: X-Hasura-Partner-Id
+  - role: user
+    permission:
+      columns: '*'
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id

--- a/hasura/metadata/databases/neon db/tables/tables.yaml
+++ b/hasura/metadata/databases/neon db/tables/tables.yaml
@@ -4,6 +4,8 @@
 - "!include public_followers.yaml"
 - "!include public_geography_columns.yaml"
 - "!include public_geometry_columns.yaml"
+- "!include public_loyalty_accounts.yaml"
+- "!include public_loyalty_transactions.yaml"
 - "!include public_menu.yaml"
 - "!include public_offers.yaml"
 - "!include public_offers_claimed.yaml"

--- a/hasura/migrations/neon db/1780200000000_create_loyalty_points/down.sql
+++ b/hasura/migrations/neon db/1780200000000_create_loyalty_points/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.orders DROP COLUMN IF EXISTS loyalty_points_earned;
+ALTER TABLE public.orders DROP COLUMN IF EXISTS loyalty_redeem_value;
+ALTER TABLE public.orders DROP COLUMN IF EXISTS loyalty_points_redeemed;
+ALTER TABLE public.partners DROP COLUMN IF EXISTS loyalty_settings;
+DROP TABLE IF EXISTS public.loyalty_transactions;
+DROP TABLE IF EXISTS public.loyalty_accounts;

--- a/hasura/migrations/neon db/1780200000000_create_loyalty_points/up.sql
+++ b/hasura/migrations/neon db/1780200000000_create_loyalty_points/up.sql
@@ -1,0 +1,62 @@
+-- Loyalty points: partner-scoped customer points backed by an append-only,
+-- HMAC-signed, hash-chained ledger.
+--
+-- loyalty_transactions is the source of truth; loyalty_accounts.balance is a
+-- verified cache (= balance_after of the latest txn). Every ledger row is
+-- signed with a server-only secret (LOYALTY_LEDGER_SECRET) and chained via
+-- prev_hash, so a balance cannot be inflated, forged, or transferred even by a
+-- holder of the (currently browser-exposed) Hasura admin secret: injected or
+-- edited rows fail signature/chain verification and are rejected, and there is
+-- no "transfer" operation at all. Deleting rows can only *reduce* a balance
+-- (a denial, never a gain) and is detectable via the chain head.
+
+CREATE TABLE IF NOT EXISTS public.loyalty_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  partner_id uuid NOT NULL REFERENCES public.partners(id) ON DELETE CASCADE,
+  balance integer NOT NULL DEFAULT 0 CHECK (balance >= 0),
+  lifetime_earned integer NOT NULL DEFAULT 0 CHECK (lifetime_earned >= 0),
+  lifetime_redeemed integer NOT NULL DEFAULT 0 CHECK (lifetime_redeemed >= 0),
+  last_seq bigint NOT NULL DEFAULT 0,
+  last_txn_id uuid,
+  last_hash text NOT NULL DEFAULT 'GENESIS',
+  flagged_at timestamptz,
+  flag_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT loyalty_accounts_user_partner_key UNIQUE (user_id, partner_id)
+);
+CREATE INDEX IF NOT EXISTS loyalty_accounts_partner_idx ON public.loyalty_accounts (partner_id);
+CREATE INDEX IF NOT EXISTS loyalty_accounts_user_idx ON public.loyalty_accounts (user_id);
+
+CREATE TABLE IF NOT EXISTS public.loyalty_transactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id uuid NOT NULL REFERENCES public.loyalty_accounts(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  partner_id uuid NOT NULL REFERENCES public.partners(id) ON DELETE CASCADE,
+  order_id uuid REFERENCES public.orders(id) ON DELETE SET NULL,
+  type text NOT NULL CHECK (type IN ('earn','redeem','refund','adjust_credit','adjust_debit')),
+  delta integer NOT NULL CHECK (delta <> 0),
+  balance_after integer NOT NULL CHECK (balance_after >= 0),
+  seq bigint NOT NULL,
+  prev_hash text NOT NULL,
+  hash text NOT NULL,
+  note text,
+  meta jsonb,
+  created_by text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT loyalty_txn_account_seq_key UNIQUE (account_id, seq)
+);
+CREATE INDEX IF NOT EXISTS loyalty_txn_account_idx ON public.loyalty_transactions (account_id, seq);
+CREATE INDEX IF NOT EXISTS loyalty_txn_user_partner_idx ON public.loyalty_transactions (user_id, partner_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS loyalty_txn_partner_idx ON public.loyalty_transactions (partner_id, created_at DESC);
+-- Idempotency: at most one earn / one redeem / one refund per order.
+CREATE UNIQUE INDEX IF NOT EXISTS loyalty_txn_order_type_key ON public.loyalty_transactions (order_id, type) WHERE order_id IS NOT NULL;
+
+-- Per-partner loyalty configuration (JSON string, mirrors prebooking_settings).
+ALTER TABLE public.partners ADD COLUMN IF NOT EXISTS loyalty_settings text;
+
+-- Redemption + earn snapshot persisted on the order for display/audit.
+ALTER TABLE public.orders ADD COLUMN IF NOT EXISTS loyalty_points_redeemed integer NOT NULL DEFAULT 0;
+ALTER TABLE public.orders ADD COLUMN IF NOT EXISTS loyalty_redeem_value double precision NOT NULL DEFAULT 0;
+ALTER TABLE public.orders ADD COLUMN IF NOT EXISTS loyalty_points_earned integer;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -40,6 +40,7 @@ export const partnerIdQuery = `
       post_payment_message
       fssai_licence_no
       feature_flags
+      loyalty_settings
       description
       phone
       district
@@ -105,6 +106,7 @@ export const partnerLoginQuery = `
       post_payment_message
       fssai_licence_no
       feature_flags
+      loyalty_settings
       description
       phone
       district
@@ -241,6 +243,7 @@ export const partnerMutation = `
     country
     state
     feature_flags
+    loyalty_settings
     subscription_details
     username
   }

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -27,6 +27,9 @@ export const getOrdersOfPartnerQuery = `
       gst_included
       extra_charges
       discounts
+      loyalty_points_redeemed
+      loyalty_redeem_value
+      loyalty_points_earned
       phone
       captain_id
       order_items {

--- a/src/api/partners.ts
+++ b/src/api/partners.ts
@@ -230,6 +230,7 @@ query GetPartnerAndOffersQuery($id: uuid! , $offer_types: [String!]) {
     storefront_settings
     prebooking_settings
     order_types_enabled
+    loyalty_settings
     timezone
     menus(where: { deletion_status: {_eq: 0} }) {
       category {
@@ -420,6 +421,7 @@ export const updatePartnerMutation = `
       storefront_settings
       prebooking_settings
       order_types_enabled
+      loyalty_settings
       official_name
       about_us
       operating_address

--- a/src/app/actions/cancelOrder.ts
+++ b/src/app/actions/cancelOrder.ts
@@ -29,6 +29,16 @@ function maybeCancelPorter(orderId: string, reason: string): void {
     );
 }
 
+/**
+ * Return any loyalty points the cancelled order had redeemed. Fire-and-forget and
+ * idempotent (one refund per order) — a cancel never fails over a refund hiccup.
+ */
+function maybeRefundLoyalty(orderId: string, reason: string): void {
+  import("@/app/actions/loyalty")
+    .then(({ refundLoyaltyForOrder }) => refundLoyaltyForOrder(orderId, reason))
+    .catch((e) => console.warn("[loyalty] cancel refund threw:", e));
+}
+
 type CancelResult =
   | { success: true }
   | { success: false; message: string };
@@ -97,6 +107,7 @@ export async function cancelOrderAction(
         return { success: false, message: "Failed to cancel order" };
       }
       maybeCancelPorter(orderId, reason);
+      maybeRefundLoyalty(orderId, "Order cancelled");
       return { success: true };
     } catch (err: any) {
       return { success: false, message: err?.message || "Failed to cancel order" };
@@ -129,6 +140,7 @@ export async function cancelOrderAction(
     }
 
     maybeCancelPorter(orderId, reason);
+    maybeRefundLoyalty(orderId, "Order cancelled");
     return { success: true };
   } catch (err: any) {
     return { success: false, message: err?.message || "Network error" };

--- a/src/app/actions/cfOrders.ts
+++ b/src/app/actions/cfOrders.ts
@@ -236,5 +236,15 @@ const EXPIRE_PENDING = `
 
 export async function expireCfOrder(orderId: string) {
   const res = await fetchFromHasura(EXPIRE_PENDING, { id: orderId });
-  return res?.update_orders?.affected_rows ?? 0;
+  const affected = res?.update_orders?.affected_rows ?? 0;
+  // Abandoned/unpaid online order — return any loyalty points it had redeemed.
+  if (affected > 0) {
+    try {
+      const { refundLoyaltyForOrder } = await import("@/app/actions/loyalty");
+      await refundLoyaltyForOrder(orderId, "Order expired (unpaid)");
+    } catch (e) {
+      console.warn("[loyalty] expire refund failed", orderId, e);
+    }
+  }
+  return affected;
 }

--- a/src/app/actions/loyalty.ts
+++ b/src/app/actions/loyalty.ts
@@ -1,0 +1,827 @@
+"use server";
+
+import { randomUUID } from "crypto";
+import { fetchFromHasuraServer } from "@/lib/hasuraServerClient";
+import { getAuthCookie } from "@/app/auth/actions";
+import { getFeatures } from "@/lib/getFeatures";
+import {
+  DELTA_SIGN,
+  parseLoyaltySettings,
+  computeEarnPoints,
+  computeMaxRedeemable,
+  pointsToValue,
+  type LoyaltySettings,
+  type LoyaltyTxnType,
+  type LoyaltyBalanceView,
+  type LoyaltyTxnView,
+  type LoyaltyMemberView,
+  type LoyaltyPartnerSummary,
+  type RedeemResult,
+} from "@/lib/loyalty/config";
+import {
+  signTxn,
+  verifyHead,
+  GENESIS_HASH,
+  type LedgerRow,
+} from "@/lib/loyalty/ledger";
+
+/*
+ * Loyalty server actions.
+ *
+ * Trust model:
+ *  - Identity comes from the encrypted httpOnly auth cookie (getAuthCookie). Loyalty
+ *    is no more forgeable than any other server action in this app; the shared
+ *    cookie-key weakness is documented in the staged migration plan.
+ *  - All DB access uses the SERVER-ONLY Hasura client; the ledger secret never leaves
+ *    the server. Every ledger row is HMAC-signed + hash-chained (see lib/loyalty/ledger).
+ *  - Balances are never trusted blindly: before any spend the cached balance is
+ *    verified against a signed head transaction; a mismatch flags the account and
+ *    blocks further writes.
+ */
+
+const SEQ_CONFLICT = "loyalty_txn_account_seq_key";
+const ORDER_TXN_CONFLICT = "loyalty_txn_order_type_key";
+
+class OrderTxnExistsError extends Error {}
+class LoyaltyIntegrityError extends Error {}
+
+function errIncludes(e: unknown, needle: string): boolean {
+  try {
+    const s = typeof e === "string" ? e : JSON.stringify((e as any)?.response ?? (e as any)?.message ?? e);
+    return (s || "").includes(needle) || String((e as any)?.message || "").includes(needle);
+  } catch {
+    return String((e as any)?.message || "").includes(needle);
+  }
+}
+
+// --------------------------------------------------------------------------
+// Auth helpers
+// --------------------------------------------------------------------------
+
+async function requireUser(): Promise<{ userId: string }> {
+  const auth = await getAuthCookie();
+  if (!auth || auth.role !== "user" || !auth.id) {
+    throw new Error("Not authenticated as a customer.");
+  }
+  return { userId: auth.id };
+}
+
+/**
+ * Resolves the partner the caller is allowed to act on. Partner accounts are
+ * locked to their own id; superadmins may target any partner via `wantPartnerId`.
+ */
+async function requirePartnerScope(wantPartnerId?: string): Promise<{ partnerId: string }> {
+  const auth = await getAuthCookie();
+  if (!auth) throw new Error("Not authenticated.");
+  if (auth.role === "partner") return { partnerId: auth.id };
+  if (auth.role === "superadmin") {
+    if (!wantPartnerId) throw new Error("partnerId required for superadmin.");
+    return { partnerId: wantPartnerId };
+  }
+  throw new Error("Not authorized to manage loyalty.");
+}
+
+// --------------------------------------------------------------------------
+// Partner config
+// --------------------------------------------------------------------------
+
+async function loadPartnerLoyalty(
+  partnerId: string
+): Promise<{ enabled: boolean; settings: LoyaltySettings }> {
+  const res = await fetchFromHasuraServer(
+    `query PartnerLoyalty($id: uuid!) {
+      partners_by_pk(id: $id) { id feature_flags loyalty_settings }
+    }`,
+    { id: partnerId }
+  );
+  const p = res?.partners_by_pk;
+  if (!p) return { enabled: false, settings: parseLoyaltySettings(null) };
+  const features = getFeatures(p.feature_flags || null);
+  const enabled = !!(features.loyalty_points?.access && features.loyalty_points?.enabled);
+  return { enabled, settings: parseLoyaltySettings(p.loyalty_settings) };
+}
+
+// --------------------------------------------------------------------------
+// Ledger append (the only writer)
+// --------------------------------------------------------------------------
+
+interface AccountRow {
+  id: string;
+  balance: number;
+  lifetime_earned: number;
+  lifetime_redeemed: number;
+  last_seq: number;
+  last_hash: string;
+  last_txn_id: string | null;
+  flagged_at: string | null;
+}
+
+const ACCOUNT_FIELDS = `id balance lifetime_earned lifetime_redeemed last_seq last_hash last_txn_id flagged_at`;
+
+async function getOrCreateAccount(userId: string, partnerId: string): Promise<AccountRow> {
+  // NOTE: on_conflict must update at least one column, otherwise Hasura runs
+  // ON CONFLICT DO NOTHING and returns null for an already-existing row. Touching
+  // updated_at is harmless and guarantees the row is returned in both cases.
+  const res = await fetchFromHasuraServer(
+    `mutation EnsureAccount($userId: uuid!, $partnerId: uuid!, $now: timestamptz!) {
+      insert_loyalty_accounts_one(
+        object: { user_id: $userId, partner_id: $partnerId, updated_at: $now },
+        on_conflict: { constraint: loyalty_accounts_user_partner_key, update_columns: [updated_at] }
+      ) { ${ACCOUNT_FIELDS} }
+    }`,
+    { userId, partnerId, now: new Date().toISOString() }
+  );
+  return res.insert_loyalty_accounts_one as AccountRow;
+}
+
+async function fetchHead(accountId: string, seq: number): Promise<LedgerRow | null> {
+  if (seq <= 0) return null;
+  const res = await fetchFromHasuraServer(
+    `query Head($acct: uuid!, $seq: bigint!) {
+      loyalty_transactions(where: { account_id: { _eq: $acct }, seq: { _eq: $seq } }, limit: 1) {
+        id account_id user_id partner_id order_id type delta balance_after seq prev_hash hash created_at
+      }
+    }`,
+    { acct: accountId, seq }
+  );
+  const r = res?.loyalty_transactions?.[0];
+  return r ? (r as LedgerRow) : null;
+}
+
+async function flagAccount(accountId: string, reason: string): Promise<void> {
+  try {
+    await fetchFromHasuraServer(
+      `mutation FlagAccount($id: uuid!, $reason: String!, $at: timestamptz!) {
+        update_loyalty_accounts_by_pk(pk_columns: { id: $id }, _set: { flagged_at: $at, flag_reason: $reason }) { id }
+      }`,
+      { id: accountId, reason: reason.slice(0, 280), at: new Date().toISOString() }
+    );
+    console.error(`[loyalty] SECURITY: account ${accountId} flagged — ${reason}`);
+  } catch (e) {
+    console.error("[loyalty] failed to flag account", accountId, e);
+  }
+}
+
+interface AppendParams {
+  userId: string;
+  partnerId: string;
+  type: LoyaltyTxnType;
+  points: number; // positive magnitude
+  orderId?: string | null;
+  note?: string | null;
+  meta?: Record<string, any> | null;
+  createdBy: string;
+}
+
+interface AppendResult {
+  txnId: string;
+  delta: number;
+  balanceAfter: number;
+  seq: number;
+}
+
+/**
+ * Append one signed transaction. Reads (or creates) the account, verifies the
+ * signed head, computes the next chained, signed row, then commits the row +
+ * account update in a single Hasura transaction. Concurrency is serialized by the
+ * UNIQUE(account_id, seq) constraint: a losing racer's insert violates it, the whole
+ * transaction rolls back, and we retry. Idempotency per order is enforced by
+ * UNIQUE(order_id, type) → surfaced as OrderTxnExistsError.
+ */
+async function appendTxn(params: AppendParams): Promise<AppendResult> {
+  const points = Math.floor(params.points);
+  if (!Number.isFinite(points) || points <= 0) {
+    throw new Error("Points must be a positive whole number.");
+  }
+  const sign = DELTA_SIGN[params.type];
+  const delta = sign * points;
+
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const account = await getOrCreateAccount(params.userId, params.partnerId);
+    if (account.flagged_at) {
+      throw new LoyaltyIntegrityError("This loyalty account is locked pending review.");
+    }
+
+    // Verify the signed head backs the cached balance before we chain onto it.
+    const head = await fetchHead(account.id, account.last_seq);
+    const headCheck = verifyHead(
+      {
+        balance: account.balance,
+        last_seq: account.last_seq,
+        last_hash: account.last_hash,
+        last_txn_id: account.last_txn_id,
+      },
+      head
+    );
+    if (!headCheck.ok) {
+      await flagAccount(account.id, `head verify failed: ${headCheck.reason}`);
+      throw new LoyaltyIntegrityError("Loyalty balance failed integrity check.");
+    }
+
+    const newBalance = account.balance + delta;
+    if (newBalance < 0) {
+      throw new Error("Insufficient loyalty points.");
+    }
+
+    const txnId = randomUUID();
+    const createdAt = new Date().toISOString();
+    const newSeq = account.last_seq + 1;
+    const prevHash = account.last_hash || GENESIS_HASH;
+    const hash = signTxn({
+      id: txnId,
+      account_id: account.id,
+      user_id: params.userId,
+      partner_id: params.partnerId,
+      order_id: params.orderId ?? null,
+      type: params.type,
+      delta,
+      balance_after: newBalance,
+      seq: newSeq,
+      prev_hash: prevHash,
+      created_at: createdAt,
+    });
+
+    const lifeEarnedInc = params.type === "earn" ? points : 0;
+    const lifeRedeemedInc = params.type === "redeem" ? points : 0;
+
+    try {
+      await fetchFromHasuraServer(
+        `mutation AppendTxn(
+          $acctId: uuid!, $txnId: uuid!, $userId: uuid!, $partnerId: uuid!, $orderId: uuid,
+          $type: String!, $delta: Int!, $newBalance: Int!, $newSeq: bigint!,
+          $prevHash: String!, $hash: String!, $note: String, $meta: jsonb, $createdBy: String,
+          $createdAt: timestamptz!, $lifeEarnedInc: Int!, $lifeRedeemedInc: Int!
+        ) {
+          insert_loyalty_transactions_one(object: {
+            id: $txnId, account_id: $acctId, user_id: $userId, partner_id: $partnerId, order_id: $orderId,
+            type: $type, delta: $delta, balance_after: $newBalance, seq: $newSeq,
+            prev_hash: $prevHash, hash: $hash, note: $note, meta: $meta, created_by: $createdBy,
+            created_at: $createdAt
+          }) { id }
+          update_loyalty_accounts_by_pk(
+            pk_columns: { id: $acctId },
+            _set: { balance: $newBalance, last_seq: $newSeq, last_hash: $hash, last_txn_id: $txnId, updated_at: $createdAt },
+            _inc: { lifetime_earned: $lifeEarnedInc, lifetime_redeemed: $lifeRedeemedInc }
+          ) { id }
+        }`,
+        {
+          acctId: account.id,
+          txnId,
+          userId: params.userId,
+          partnerId: params.partnerId,
+          orderId: params.orderId ?? null,
+          type: params.type,
+          delta,
+          newBalance,
+          newSeq,
+          prevHash,
+          hash,
+          note: params.note ?? null,
+          meta: params.meta ?? null,
+          createdBy: params.createdBy,
+          createdAt,
+          lifeEarnedInc,
+          lifeRedeemedInc,
+        }
+      );
+      return { txnId, delta, balanceAfter: newBalance, seq: newSeq };
+    } catch (e) {
+      if (errIncludes(e, ORDER_TXN_CONFLICT)) {
+        throw new OrderTxnExistsError("A loyalty transaction of this type already exists for the order.");
+      }
+      if (errIncludes(e, SEQ_CONFLICT)) {
+        // Lost the optimistic race — another writer advanced the sequence. Retry.
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw new Error("Could not record loyalty transaction (too much contention). Please retry.");
+}
+
+// --------------------------------------------------------------------------
+// Customer reads
+// --------------------------------------------------------------------------
+
+export async function getLoyaltyBalance(partnerId: string): Promise<LoyaltyBalanceView | null> {
+  if (!partnerId) return null;
+  const auth = await getAuthCookie();
+  if (!auth || auth.role !== "user") return null;
+
+  const { enabled, settings } = await loadPartnerLoyalty(partnerId);
+  if (!enabled) return { enabled: false, balance: 0, lifetimeEarned: 0, lifetimeRedeemed: 0, pointValue: settings.point_value };
+
+  const res = await fetchFromHasuraServer(
+    `query Bal($userId: uuid!, $partnerId: uuid!) {
+      loyalty_accounts(where: { user_id: { _eq: $userId }, partner_id: { _eq: $partnerId } }, limit: 1) {
+        balance lifetime_earned lifetime_redeemed
+      }
+    }`,
+    { userId: auth.id, partnerId }
+  );
+  const a = res?.loyalty_accounts?.[0];
+  return {
+    enabled: true,
+    balance: a?.balance ?? 0,
+    lifetimeEarned: a?.lifetime_earned ?? 0,
+    lifetimeRedeemed: a?.lifetime_redeemed ?? 0,
+    pointValue: settings.point_value,
+  };
+}
+
+export async function getLoyaltyHistory(
+  partnerId: string,
+  limit = 30,
+  offset = 0
+): Promise<LoyaltyTxnView[]> {
+  const auth = await getAuthCookie();
+  if (!auth || auth.role !== "user" || !partnerId) return [];
+  const res = await fetchFromHasuraServer(
+    `query Hist($userId: uuid!, $partnerId: uuid!, $limit: Int!, $offset: Int!) {
+      loyalty_transactions(
+        where: { user_id: { _eq: $userId }, partner_id: { _eq: $partnerId } },
+        order_by: { seq: desc }, limit: $limit, offset: $offset
+      ) {
+        id type delta balance_after created_at note order_id
+        order { display_id }
+      }
+    }`,
+    { userId: auth.id, partnerId, limit: Math.min(100, Math.max(1, limit)), offset: Math.max(0, offset) }
+  );
+  return (res?.loyalty_transactions || []).map((t: any): LoyaltyTxnView => ({
+    id: t.id,
+    type: t.type,
+    delta: t.delta,
+    balanceAfter: t.balance_after,
+    createdAt: t.created_at,
+    note: t.note ?? null,
+    orderId: t.order_id ?? null,
+    orderDisplayId: t.order?.display_id ?? null,
+  }));
+}
+
+// --------------------------------------------------------------------------
+// Earn (system, on order completion)
+// --------------------------------------------------------------------------
+
+/**
+ * Idempotently award points for a completed order. Re-reads the order server-side
+ * (never trusts the caller's claims) and only earns if the order is completed, has a
+ * customer, and the partner has loyalty enabled. Safe to call from any completion path.
+ */
+export async function awardLoyaltyForOrder(
+  orderId: string
+): Promise<{ ok: boolean; points: number; reason?: string }> {
+  if (!orderId) return { ok: false, points: 0, reason: "no order id" };
+  try {
+    const res = await fetchFromHasuraServer(
+      `query OrderForAward($id: uuid!) {
+        orders_by_pk(id: $id) { id user_id partner_id total_price status loyalty_points_earned }
+      }`,
+      { id: orderId }
+    );
+    const o = res?.orders_by_pk;
+    if (!o) return { ok: false, points: 0, reason: "order not found" };
+    if (o.status !== "completed") return { ok: false, points: 0, reason: "order not completed" };
+    if (!o.user_id) return { ok: false, points: 0, reason: "guest order" };
+    if (o.loyalty_points_earned !== null && o.loyalty_points_earned !== undefined) {
+      return { ok: true, points: o.loyalty_points_earned, reason: "already awarded" };
+    }
+
+    const { enabled, settings } = await loadPartnerLoyalty(o.partner_id);
+    if (!enabled) return { ok: false, points: 0, reason: "loyalty disabled" };
+
+    const points = computeEarnPoints(Number(o.total_price) || 0, settings);
+
+    if (points > 0) {
+      try {
+        await appendTxn({
+          userId: o.user_id,
+          partnerId: o.partner_id,
+          type: "earn",
+          points,
+          orderId: o.id,
+          note: `Earned on order`,
+          meta: { order_total: o.total_price, earn_percent: settings.earn_percent, point_value: settings.point_value },
+          createdBy: "system:order-complete",
+        });
+      } catch (e) {
+        if (e instanceof OrderTxnExistsError) {
+          // Earn already recorded by a concurrent completion trigger — fine.
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    // Snapshot on the order (display + fast idempotency on future triggers).
+    await fetchFromHasuraServer(
+      `mutation MarkEarned($id: uuid!, $pts: Int!) {
+        update_orders_by_pk(pk_columns: { id: $id }, _set: { loyalty_points_earned: $pts }) { id }
+      }`,
+      { id: orderId, pts: points }
+    );
+
+    return { ok: true, points };
+  } catch (e) {
+    console.error("[loyalty] awardLoyaltyForOrder failed", orderId, e);
+    return { ok: false, points: 0, reason: (e as Error)?.message };
+  }
+}
+
+// --------------------------------------------------------------------------
+// Redeem (customer, at checkout)
+// --------------------------------------------------------------------------
+
+async function accountBalance(userId: string, partnerId: string): Promise<number> {
+  const res = await fetchFromHasuraServer(
+    `query Bal($u: uuid!, $p: uuid!) {
+      loyalty_accounts(where: { user_id: { _eq: $u }, partner_id: { _eq: $p } }, limit: 1) { balance }
+    }`,
+    { u: userId, p: partnerId }
+  );
+  return res?.loyalty_accounts?.[0]?.balance ?? 0;
+}
+
+/**
+ * Everything the checkout UI needs to render the "use points" control, without
+ * leaking anything sensitive. Returns enabled=false (and zeroed values) for guests
+ * or partners without loyalty.
+ */
+export async function getLoyaltyRedeemContext(partnerId: string): Promise<{
+  enabled: boolean;
+  balance: number;
+  pointValue: number;
+  minRedeemPoints: number;
+  maxRedeemPercent: number;
+}> {
+  const auth = await getAuthCookie();
+  const { enabled, settings } = await loadPartnerLoyalty(partnerId);
+  const base = {
+    pointValue: settings.point_value,
+    minRedeemPoints: settings.min_redeem_points,
+    maxRedeemPercent: settings.max_redeem_percent,
+  };
+  if (!auth || auth.role !== "user" || !enabled || !partnerId) {
+    return { enabled: false, balance: 0, ...base };
+  }
+  return { enabled: true, balance: await accountBalance(auth.id, partnerId), ...base };
+}
+
+/**
+ * Apply points to an ALREADY-CREATED order (FK requires the order row to exist).
+ * The order is the source of truth: we read its current `total_price` as the
+ * pre-redemption base (never trusting a client-supplied amount), verify the order
+ * belongs to the caller, clamp the request to the live balance + bill cap, write the
+ * signed redeem row, and CORRECT the order's stored total + loyalty fields. Returns
+ * the authoritative figures — the online-payment path MUST charge `orderTotal`.
+ * Idempotent per order (re-entry returns the existing redemption, never double-spends).
+ */
+export async function redeemLoyaltyPoints(args: {
+  orderId: string;
+  points: number;
+}): Promise<RedeemResult> {
+  const { orderId } = args;
+  try {
+    const { userId } = await requireUser();
+
+    const ores = await fetchFromHasuraServer(
+      `query OrderForRedeem($id: uuid!) {
+        orders_by_pk(id: $id) { id user_id partner_id total_price status loyalty_points_redeemed loyalty_redeem_value }
+      }`,
+      { id: orderId }
+    );
+    const o = ores?.orders_by_pk;
+    if (!o) return { ok: false, points: 0, value: 0, orderTotal: 0, newBalance: 0, message: "Order not found." };
+    if (o.user_id !== userId) {
+      return { ok: false, points: 0, value: 0, orderTotal: o.total_price, newBalance: 0, message: "This order isn't yours." };
+    }
+
+    const base = Math.max(0, Number(o.total_price) || 0);
+
+    // Idempotent fast-path: already redeemed → total is already corrected.
+    if (o.loyalty_points_redeemed && o.loyalty_points_redeemed > 0) {
+      return {
+        ok: true,
+        points: o.loyalty_points_redeemed,
+        value: Number(o.loyalty_redeem_value) || 0,
+        orderTotal: base,
+        newBalance: await accountBalance(userId, o.partner_id),
+        message: "Already redeemed for this order.",
+      };
+    }
+
+    const { enabled, settings } = await loadPartnerLoyalty(o.partner_id);
+    if (!enabled) return { ok: false, points: 0, value: 0, orderTotal: base, newBalance: 0, message: "Loyalty not enabled." };
+
+    const want = Math.floor(args.points);
+    if (!Number.isFinite(want) || want <= 0) {
+      return { ok: false, points: 0, value: 0, orderTotal: base, newBalance: 0, message: "No points to redeem." };
+    }
+
+    const balance = await accountBalance(userId, o.partner_id);
+    const maxPoints = computeMaxRedeemable(base, balance, settings);
+    const points = Math.min(want, maxPoints);
+    if (points < settings.min_redeem_points || points <= 0) {
+      return { ok: false, points: 0, value: 0, orderTotal: base, newBalance: balance, message: "Not enough points to redeem." };
+    }
+
+    const value = pointsToValue(points, settings);
+    const orderTotal = Math.max(0, Math.round((base - value) * 100) / 100);
+
+    let newBalance = balance - points;
+    try {
+      const r = await appendTxn({
+        userId,
+        partnerId: o.partner_id,
+        type: "redeem",
+        points,
+        orderId,
+        note: "Redeemed on order",
+        meta: { value, order_total_before: base, point_value: settings.point_value },
+        createdBy: `user:${userId}`,
+      });
+      newBalance = r.balanceAfter;
+    } catch (e) {
+      if (e instanceof OrderTxnExistsError) {
+        // Ledger redeem exists but order fields weren't set (rare crash window) — reconcile.
+        const existing = await getOrderRedeemTxn(orderId);
+        if (existing) {
+          const v = pointsToValue(existing.points, settings);
+          const t = Math.max(0, Math.round((base - v) * 100) / 100);
+          await setOrderRedemption(orderId, existing.points, v, t);
+          return { ok: true, points: existing.points, value: v, orderTotal: t, newBalance: existing.balance_after };
+        }
+      }
+      throw e;
+    }
+
+    await setOrderRedemption(orderId, points, value, orderTotal);
+    return { ok: true, points, value, orderTotal, newBalance };
+  } catch (e) {
+    console.error("[loyalty] redeemLoyaltyPoints failed", orderId, e);
+    return { ok: false, points: 0, value: 0, orderTotal: 0, newBalance: 0, message: (e as Error)?.message || "Could not redeem points." };
+  }
+}
+
+async function setOrderRedemption(
+  orderId: string,
+  points: number,
+  value: number,
+  newTotal: number
+): Promise<void> {
+  await fetchFromHasuraServer(
+    `mutation SetOrderRedemption($id: uuid!, $pts: Int!, $val: float8!, $total: float8!) {
+      update_orders_by_pk(pk_columns: { id: $id }, _set: {
+        loyalty_points_redeemed: $pts, loyalty_redeem_value: $val, total_price: $total
+      }) { id }
+    }`,
+    { id: orderId, pts: points, val: value, total: newTotal }
+  );
+}
+
+async function getOrderRedeemTxn(
+  orderId: string
+): Promise<{ points: number; balance_after: number } | null> {
+  const res = await fetchFromHasuraServer(
+    `query OrderRedeem($id: uuid!) {
+      loyalty_transactions(where: { order_id: { _eq: $id }, type: { _eq: "redeem" } }, limit: 1) {
+        delta balance_after
+      }
+    }`,
+    { id: orderId }
+  );
+  const t = res?.loyalty_transactions?.[0];
+  if (!t) return null;
+  return { points: Math.abs(t.delta), balance_after: t.balance_after };
+}
+
+/**
+ * Return points that were redeemed on an order that ultimately failed (payment
+ * failed / expired / cancelled). Idempotent: at most one refund per order, and only
+ * if a redeem exists.
+ */
+export async function refundLoyaltyForOrder(
+  orderId: string,
+  reason = "Order cancelled"
+): Promise<{ ok: boolean; points: number; reason?: string }> {
+  if (!orderId) return { ok: false, points: 0, reason: "no order id" };
+  try {
+    const res = await fetchFromHasuraServer(
+      `query RefundLookup($id: uuid!) {
+        redeem: loyalty_transactions(where: { order_id: { _eq: $id }, type: { _eq: "redeem" } }, limit: 1) {
+          user_id partner_id delta
+        }
+        refund: loyalty_transactions(where: { order_id: { _eq: $id }, type: { _eq: "refund" } }, limit: 1) { id }
+      }`,
+      { id: orderId }
+    );
+    const redeem = res?.redeem?.[0];
+    if (!redeem) return { ok: true, points: 0, reason: "nothing redeemed" };
+    if (res?.refund?.[0]) return { ok: true, points: Math.abs(redeem.delta), reason: "already refunded" };
+
+    const points = Math.abs(redeem.delta);
+    try {
+      await appendTxn({
+        userId: redeem.user_id,
+        partnerId: redeem.partner_id,
+        type: "refund",
+        points,
+        orderId,
+        note: reason,
+        meta: { reason },
+        createdBy: "system:refund",
+      });
+    } catch (e) {
+      if (e instanceof OrderTxnExistsError) return { ok: true, points, reason: "already refunded" };
+      throw e;
+    }
+    return { ok: true, points };
+  } catch (e) {
+    console.error("[loyalty] refundLoyaltyForOrder failed", orderId, e);
+    return { ok: false, points: 0, reason: (e as Error)?.message };
+  }
+}
+
+/**
+ * Loyalty redemption/earn snapshot for one order, for the admin order detail and
+ * the customer's order view. Access is limited to the order's partner, the order's
+ * customer, or a superadmin.
+ */
+export async function getOrderLoyaltyInfo(
+  orderId: string
+): Promise<{ pointsRedeemed: number; redeemValue: number; pointsEarned: number | null }> {
+  const empty = { pointsRedeemed: 0, redeemValue: 0, pointsEarned: null as number | null };
+  if (!orderId) return empty;
+  const auth = await getAuthCookie();
+  if (!auth) return empty;
+  try {
+    const res = await fetchFromHasuraServer(
+      `query OrderLoyalty($id: uuid!) {
+        orders_by_pk(id: $id) { user_id partner_id loyalty_points_redeemed loyalty_redeem_value loyalty_points_earned }
+      }`,
+      { id: orderId }
+    );
+    const o = res?.orders_by_pk;
+    if (!o) return empty;
+    const allowed =
+      auth.role === "superadmin" ||
+      (auth.role === "partner" && o.partner_id === auth.id) ||
+      (auth.role === "user" && o.user_id === auth.id);
+    if (!allowed) return empty;
+    return {
+      pointsRedeemed: o.loyalty_points_redeemed ?? 0,
+      redeemValue: Number(o.loyalty_redeem_value) || 0,
+      pointsEarned: o.loyalty_points_earned ?? null,
+    };
+  } catch (e) {
+    console.error("[loyalty] getOrderLoyaltyInfo failed", orderId, e);
+    return empty;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Partner admin
+// --------------------------------------------------------------------------
+
+export async function getPartnerLoyaltySummary(
+  wantPartnerId?: string
+): Promise<LoyaltyPartnerSummary> {
+  const { partnerId } = await requirePartnerScope(wantPartnerId);
+  const { settings } = await loadPartnerLoyalty(partnerId);
+  const res = await fetchFromHasuraServer(
+    `query Summary($pid: uuid!) {
+      members: loyalty_accounts_aggregate(where: { partner_id: { _eq: $pid } }) {
+        aggregate { count sum { balance lifetime_earned lifetime_redeemed } }
+      }
+    }`,
+    { pid: partnerId }
+  );
+  const agg = res?.members?.aggregate;
+  const outstanding = agg?.sum?.balance ?? 0;
+  return {
+    members: agg?.count ?? 0,
+    outstandingPoints: outstanding,
+    outstandingValue: pointsToValue(outstanding, settings),
+    lifetimeIssued: agg?.sum?.lifetime_earned ?? 0,
+    lifetimeRedeemed: agg?.sum?.lifetime_redeemed ?? 0,
+  };
+}
+
+export async function getPartnerLoyaltyMembers(
+  args: { search?: string; limit?: number; offset?: number; partnerId?: string } = {}
+): Promise<LoyaltyMemberView[]> {
+  const { partnerId } = await requirePartnerScope(args.partnerId);
+  const limit = Math.min(100, Math.max(1, args.limit ?? 30));
+  const offset = Math.max(0, args.offset ?? 0);
+  const search = (args.search || "").trim();
+  const where: any = { partner_id: { _eq: partnerId } };
+  if (search) {
+    where.user = { _or: [{ full_name: { _ilike: `%${search}%` } }, { phone: { _ilike: `%${search}%` } }] };
+  }
+  const res = await fetchFromHasuraServer(
+    `query Members($where: loyalty_accounts_bool_exp!, $limit: Int!, $offset: Int!) {
+      loyalty_accounts(where: $where, order_by: { balance: desc }, limit: $limit, offset: $offset) {
+        user_id balance lifetime_earned lifetime_redeemed updated_at flagged_at
+        user { full_name phone }
+      }
+    }`,
+    { where, limit, offset }
+  );
+  return (res?.loyalty_accounts || []).map((a: any): LoyaltyMemberView => ({
+    userId: a.user_id,
+    name: a.user?.full_name || "Customer",
+    phone: a.user?.phone || "",
+    balance: a.balance,
+    lifetimeEarned: a.lifetime_earned,
+    lifetimeRedeemed: a.lifetime_redeemed,
+    updatedAt: a.updated_at,
+    flagged: !!a.flagged_at,
+  }));
+}
+
+export async function getCustomerLoyaltyForPartner(
+  userId: string,
+  wantPartnerId?: string
+): Promise<{ member: LoyaltyMemberView | null; history: LoyaltyTxnView[] }> {
+  const { partnerId } = await requirePartnerScope(wantPartnerId);
+  const res = await fetchFromHasuraServer(
+    `query CustDetail($uid: uuid!, $pid: uuid!) {
+      loyalty_accounts(where: { user_id: { _eq: $uid }, partner_id: { _eq: $pid } }, limit: 1) {
+        user_id balance lifetime_earned lifetime_redeemed updated_at flagged_at
+        user { full_name phone }
+      }
+      loyalty_transactions(
+        where: { user_id: { _eq: $uid }, partner_id: { _eq: $pid } },
+        order_by: { seq: desc }, limit: 100
+      ) { id type delta balance_after created_at note order_id order { display_id } }
+    }`,
+    { uid: userId, pid: partnerId }
+  );
+  const a = res?.loyalty_accounts?.[0];
+  const member: LoyaltyMemberView | null = a
+    ? {
+        userId: a.user_id,
+        name: a.user?.full_name || "Customer",
+        phone: a.user?.phone || "",
+        balance: a.balance,
+        lifetimeEarned: a.lifetime_earned,
+        lifetimeRedeemed: a.lifetime_redeemed,
+        updatedAt: a.updated_at,
+        flagged: !!a.flagged_at,
+      }
+    : null;
+  const history: LoyaltyTxnView[] = (res?.loyalty_transactions || []).map((t: any) => ({
+    id: t.id,
+    type: t.type,
+    delta: t.delta,
+    balanceAfter: t.balance_after,
+    createdAt: t.created_at,
+    note: t.note ?? null,
+    orderId: t.order_id ?? null,
+    orderDisplayId: t.order?.display_id ?? null,
+  }));
+  return { member, history };
+}
+
+/** Manual partner grant/deduct. Caller must own the partner (or be superadmin). */
+export async function adminAdjustLoyalty(args: {
+  userId: string;
+  points: number;
+  direction: "credit" | "debit";
+  note?: string;
+  partnerId?: string;
+}): Promise<{ ok: boolean; newBalance?: number; message?: string }> {
+  try {
+    const { partnerId } = await requirePartnerScope(args.partnerId);
+    const points = Math.floor(args.points);
+    if (!Number.isFinite(points) || points <= 0) {
+      return { ok: false, message: "Enter a positive whole number of points." };
+    }
+    if (!args.userId) return { ok: false, message: "No customer selected." };
+
+    const type: LoyaltyTxnType = args.direction === "debit" ? "adjust_debit" : "adjust_credit";
+    const actor = await getAuthCookie();
+    try {
+      const r = await appendTxn({
+        userId: args.userId,
+        partnerId,
+        type,
+        points,
+        orderId: null,
+        note: (args.note || "").slice(0, 280) || (args.direction === "debit" ? "Adjustment (debit)" : "Adjustment (credit)"),
+        meta: { manual: true },
+        createdBy: `partner:${actor?.id || partnerId}`,
+      });
+      return { ok: true, newBalance: r.balanceAfter };
+    } catch (e) {
+      if ((e as Error)?.message?.includes("Insufficient")) {
+        return { ok: false, message: "Customer doesn't have enough points to deduct." };
+      }
+      throw e;
+    }
+  } catch (e) {
+    console.error("[loyalty] adminAdjustLoyalty failed", e);
+    return { ok: false, message: (e as Error)?.message || "Could not adjust points." };
+  }
+}

--- a/src/app/admin-v2/page.tsx
+++ b/src/app/admin-v2/page.tsx
@@ -74,6 +74,9 @@ const AdminV2WhatsAppTemplates = dynamic(() => import("@/components/admin-v2/Adm
 const AdminV2WhatsAppInbox = dynamic(() => import("@/components/admin-v2/AdminV2WhatsAppInbox").then(mod => mod.AdminV2WhatsAppInbox), {
     loading: () => <div className="h-full w-full flex items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-orange-600" /></div>
 });
+const AdminV2Loyalty = dynamic(() => import("@/components/admin-v2/AdminV2Loyalty").then(mod => mod.AdminV2Loyalty), {
+    loading: () => <div className="h-full w-full flex items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-orange-600" /></div>
+});
 import { useAdminStore } from "@/store/adminStore";
 import { UpgradePlanDialog } from "@/components/admin-v2/UpgradePlanDialog";
 
@@ -154,7 +157,7 @@ export default function AdminPage() {
 
                     {/* Main Content */}
                     <main className={`flex-1 overflow-y-auto ${activeView === "POS" ? "p-0 md:p-2" : "p-3 sm:p-4 md:p-6"}`}>
-                        {activeView !== "Menu" && activeView !== "Settings" && activeView !== "Captains" && activeView !== "Delivery Boys" && activeView !== "QrCodes" && activeView !== "Offers" && activeView !== "Help & Support" && activeView !== "POS" && activeView !== "Purchase & Inventory" && activeView !== "Dashboard" && activeView !== "Billing" && activeView !== "Customers" && activeView !== "Notices" && activeView !== "Reviews" && activeView !== "Website" && activeView !== "Notify" && activeView !== "Petpooja Integration" && activeView !== "Delivery Service Integration" && activeView !== "WhatsApp Templates" && activeView !== "WhatsApp Inbox" && (
+                        {activeView !== "Menu" && activeView !== "Settings" && activeView !== "Captains" && activeView !== "Delivery Boys" && activeView !== "QrCodes" && activeView !== "Offers" && activeView !== "Help & Support" && activeView !== "POS" && activeView !== "Purchase & Inventory" && activeView !== "Dashboard" && activeView !== "Billing" && activeView !== "Customers" && activeView !== "Notices" && activeView !== "Reviews" && activeView !== "Website" && activeView !== "Notify" && activeView !== "Petpooja Integration" && activeView !== "Delivery Service Integration" && activeView !== "WhatsApp Templates" && activeView !== "WhatsApp Inbox" && activeView !== "Loyalty" && (
                             <h1 className="text-3xl font-bold mb-6">{activeView}</h1>
                         )}
 
@@ -226,6 +229,11 @@ export default function AdminPage() {
                         {renderedViews.includes("Customers") && (
                             <div className={activeView === "Customers" ? "block" : "hidden"}>
                                 <AdminV2Customers />
+                            </div>
+                        )}
+                        {renderedViews.includes("Loyalty") && (
+                            <div className={activeView === "Loyalty" ? "block" : "hidden"}>
+                                <AdminV2Loyalty />
                             </div>
                         )}
                         {renderedViews.includes("Notices") && (

--- a/src/app/api/loyalty/award/route.ts
+++ b/src/app/api/loyalty/award/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { awardLoyaltyForOrder } from "@/app/actions/loyalty";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * Loyalty earn webhook — an OPTIONAL bulletproof backstop to the in-app hooks in
+ * orderStore/posStore. Wire a Hasura event trigger on `orders` (UPDATE) to POST here
+ * so points are awarded the instant any path marks an order completed — even a direct
+ * DB update or a path we don't yet cover.
+ *
+ * Auth: send `Authorization: Bearer <CRON_SECRET>` (configure the same secret as the
+ * trigger header). If CRON_SECRET is unset we allow (so it works before configuration).
+ *
+ * Accepts either:
+ *   - a Hasura event payload: { event: { data: { new: { id, status } } } }
+ *   - a plain body: { orderId: "<uuid>" }
+ *
+ * awardLoyaltyForOrder is idempotent and self-gating, so duplicate/irrelevant calls
+ * are harmless no-ops.
+ */
+async function handle(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = req.headers.get("authorization");
+    if (auth !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+  }
+
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+
+  const newRow = body?.event?.data?.new;
+  const orderId: string | undefined = newRow?.id || body?.orderId || body?.order_id;
+  if (!orderId) {
+    return NextResponse.json({ error: "no order id" }, { status: 400 });
+  }
+
+  // If this came from an event trigger, only act on the completed transition.
+  if (newRow && newRow.status && newRow.status !== "completed") {
+    return NextResponse.json({ ok: true, skipped: "not completed" });
+  }
+
+  const result = await awardLoyaltyForOrder(orderId);
+  return NextResponse.json(result);
+}
+
+export async function POST(req: NextRequest) {
+  return handle(req);
+}

--- a/src/app/bill/[id]/page.tsx
+++ b/src/app/bill/[id]/page.tsx
@@ -66,6 +66,8 @@ query GetOrder($id: uuid!) {
     gst_included
     extra_charges
     discounts
+    loyalty_points_redeemed
+    loyalty_redeem_value
     phone
     user_id
     user {
@@ -652,6 +654,15 @@ const PrintOrderPage = () => {
               <span>
                 {currency}
                 {gstAmount.toFixed(2)}
+              </span>
+            </div>
+          )}
+          {(order.loyalty_points_redeemed ?? 0) > 0 && (
+            <div className="flex justify-between">
+              <span>Loyalty Points ({order.loyalty_points_redeemed} pts):</span>
+              <span>
+                -{currency}
+                {Number(order.loyalty_redeem_value || 0).toFixed(2)}
               </span>
             </div>
           )}

--- a/src/app/order/[id]/OrderClient.tsx
+++ b/src/app/order/[id]/OrderClient.tsx
@@ -10,6 +10,8 @@ import { useLiveAgentLocation } from "@/hooks/useLiveAgentLocation";
 import { fetchFromHasura } from "@/lib/hasuraClient";
 import { Order, OrderItem } from "@/store/orderStore";
 import OfferLoadinPage from "@/components/OfferLoadinPage";
+import { getOrderLoyaltyInfo } from "@/app/actions/loyalty";
+import { LoyaltyPointsBadge } from "@/components/loyalty/LoyaltyPointsBadge";
 import { getStatusDisplay } from "@/lib/getStatusDisplay";
 import { getFeatures } from "@/lib/getFeatures";
 import { ArrowLeft, MessageCircle, CreditCard, Phone, Truck, Loader2, Star, Bike, Store, MapPin, Receipt, Package, User, StickyNote, ShoppingBag, XCircle, ChevronDown, CalendarClock } from "lucide-react";
@@ -118,6 +120,7 @@ const OrderClient = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [showUpiScreen, setShowUpiScreen] = useState(false);
+    const [loyaltyInfo, setLoyaltyInfo] = useState<{ pointsRedeemed: number; redeemValue: number; pointsEarned: number | null } | null>(null);
     const [partnerPaymentInfo, setPartnerPaymentInfo] = useState<{
         upi_id?: string;
         show_payment_qr?: boolean;
@@ -325,6 +328,17 @@ const OrderClient = () => {
             })
             .catch(() => setCashfreeVerifying(false));
     }, [orderId]);
+
+    // Loyalty redemption/earn snapshot for this order (re-reads when status changes,
+    // e.g. once it's completed and points are awarded).
+    useEffect(() => {
+        if (!orderId) return;
+        let cancelled = false;
+        getOrderLoyaltyInfo(orderId)
+            .then((info) => { if (!cancelled) setLoyaltyInfo(info); })
+            .catch(() => { });
+        return () => { cancelled = true; };
+    }, [orderId, order?.status]);
 
     // Use total_price directly from DB
     const grandTotal = order?.totalPrice || 0;
@@ -1129,11 +1143,38 @@ ${itemsText}
                                     </div>
                                 )}
 
+                                {loyaltyInfo && loyaltyInfo.pointsRedeemed > 0 && (
+                                    <div className="flex justify-between text-orange-600 font-medium">
+                                        <span>Loyalty points ({loyaltyInfo.pointsRedeemed} pts)</span>
+                                        <span>
+                                            −{order?.partner?.currency || "₹"}{loyaltyInfo.redeemValue.toFixed(2)}
+                                        </span>
+                                    </div>
+                                )}
+
                                 <div className="border-t border-dashed mt-2 pt-2 flex justify-between text-base font-bold text-gray-900">
                                     <span>To pay</span>
                                     <span>{order?.partner?.currency || "₹"}{grandTotal.toFixed(2)}</span>
                                 </div>
                             </div>
+
+                            {/* Loyalty points summary + history */}
+                            {order?.partnerId && loyaltyInfo && (loyaltyInfo.pointsEarned != null || loyaltyInfo.pointsRedeemed > 0) && (
+                                <div className="mt-3 flex items-center justify-between gap-3 rounded-xl bg-orange-50 px-4 py-3">
+                                    <div className="text-sm text-orange-900">
+                                        {loyaltyInfo.pointsEarned != null && loyaltyInfo.pointsEarned > 0 ? (
+                                            <>You earned <span className="font-bold">{loyaltyInfo.pointsEarned} points</span> on this order 🎉</>
+                                        ) : (
+                                            <>You redeemed <span className="font-bold">{loyaltyInfo.pointsRedeemed} points</span> on this order</>
+                                        )}
+                                    </div>
+                                    <LoyaltyPointsBadge
+                                        partnerId={order.partnerId}
+                                        currency={order?.partner?.currency || "₹"}
+                                        storeName={order?.partner?.store_name}
+                                    />
+                                </div>
+                            )}
                         </div>
 
                         {/* Card: Delivery details (delivery only) */}

--- a/src/components/admin-v2/AdminSidebar.tsx
+++ b/src/components/admin-v2/AdminSidebar.tsx
@@ -22,6 +22,7 @@ import {
   Bike,
   MessageSquare,
   Inbox,
+  Gift,
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
@@ -51,6 +52,7 @@ const sidebarItems: SidebarItem[] = [
   { title: "Delivery Boys", icon: Truck, id: "deliveryboys" },
   { title: "POS", icon: CreditCard, id: "pos" },
   { title: "Customers", icon: Users, id: "customers" },
+  { title: "Loyalty", icon: Gift, id: "loyalty" },
   { title: "Website", icon: Globe, id: "website" },
   { title: "WhatsApp Inbox", icon: Inbox, id: "whatsapp-inbox" },
   { title: "WhatsApp Templates", icon: MessageSquare, id: "whatsapp-templates" },
@@ -80,6 +82,7 @@ const FREE_PLAN_LOCKED_IDS = [
   "reviews",
   "whatsapp-templates",
   "whatsapp-inbox",
+  "loyalty",
 ];
 
 interface AdminSidebarProps {
@@ -141,6 +144,9 @@ export function AdminSidebar({
     }
     if (item.id === "whatsapp-inbox") {
       return features?.whatsappOrdering?.enabled ? "visible" : "hidden";
+    }
+    if (item.id === "loyalty") {
+      return features?.loyalty_points?.enabled ? "visible" : "hidden";
     }
     return "visible";
   };

--- a/src/components/admin-v2/AdminV2Loyalty.tsx
+++ b/src/components/admin-v2/AdminV2Loyalty.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuthStore } from "@/store/authStore";
+import { getFeatures } from "@/lib/getFeatures";
+import { toast } from "sonner";
+import {
+  Gift,
+  Search,
+  Users,
+  Coins,
+  TrendingUp,
+  TrendingDown,
+  ChevronRight,
+  Plus,
+  Minus,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react";
+import {
+  getPartnerLoyaltySummary,
+  getPartnerLoyaltyMembers,
+  getCustomerLoyaltyForPartner,
+  adminAdjustLoyalty,
+} from "@/app/actions/loyalty";
+import {
+  loyaltyTxnLabel,
+  type LoyaltyMemberView,
+  type LoyaltyPartnerSummary,
+  type LoyaltyTxnView,
+} from "@/lib/loyalty/config";
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleString(undefined, { day: "numeric", month: "short", hour: "numeric", minute: "2-digit" });
+
+function StatCard({ icon: Icon, label, value, sub }: { icon: any; label: string; value: string; sub?: string }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-center gap-2 text-muted-foreground text-xs font-medium">
+          <Icon className="h-4 w-4" />
+          {label}
+        </div>
+        <div className="mt-1 text-2xl font-bold tracking-tight">{value}</div>
+        {sub && <div className="text-xs text-muted-foreground mt-0.5">{sub}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TxnRow({ txn, currency }: { txn: LoyaltyTxnView; currency: string }) {
+  const credit = txn.delta > 0;
+  return (
+    <div className="flex items-center justify-between py-2.5">
+      <div className="min-w-0">
+        <div className="text-sm font-medium">{loyaltyTxnLabel(txn.type)}</div>
+        <div className="text-xs text-muted-foreground truncate">
+          {fmtDate(txn.createdAt)}
+          {txn.orderDisplayId ? ` · #${txn.orderDisplayId}` : ""}
+          {txn.note ? ` · ${txn.note}` : ""}
+        </div>
+      </div>
+      <div className="text-right shrink-0 pl-3">
+        <div className={`text-sm font-bold ${credit ? "text-emerald-600" : "text-orange-600"}`}>
+          {credit ? "+" : ""}
+          {txn.delta} pts
+        </div>
+        <div className="text-[11px] text-muted-foreground">bal {txn.balanceAfter}</div>
+      </div>
+    </div>
+  );
+}
+
+export function AdminV2Loyalty() {
+  const { userData } = useAuthStore();
+  const currency = (userData as any)?.currency || "₹";
+  const enabled = !!getFeatures((userData as any)?.feature_flags || null).loyalty_points?.access;
+
+  const [summary, setSummary] = useState<LoyaltyPartnerSummary | null>(null);
+  const [members, setMembers] = useState<LoyaltyMemberView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+
+  // Detail drawer
+  const [selected, setSelected] = useState<LoyaltyMemberView | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [history, setHistory] = useState<LoyaltyTxnView[]>([]);
+  const [detailMember, setDetailMember] = useState<LoyaltyMemberView | null>(null);
+  const [adjustDir, setAdjustDir] = useState<"credit" | "debit">("credit");
+  const [adjustPoints, setAdjustPoints] = useState("");
+  const [adjustNote, setAdjustNote] = useState("");
+  const [adjusting, setAdjusting] = useState(false);
+
+  const loadList = useCallback(async (term: string) => {
+    setLoading(true);
+    try {
+      const [s, m] = await Promise.all([
+        getPartnerLoyaltySummary(),
+        getPartnerLoyaltyMembers({ search: term, limit: 100 }),
+      ]);
+      setSummary(s);
+      setMembers(m);
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to load loyalty data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (enabled) loadList("");
+  }, [enabled, loadList]);
+
+  // Debounced search
+  useEffect(() => {
+    if (!enabled) return;
+    const t = setTimeout(() => loadList(search.trim()), 350);
+    return () => clearTimeout(t);
+  }, [search, enabled, loadList]);
+
+  const openDetail = async (m: LoyaltyMemberView) => {
+    setSelected(m);
+    setDetailMember(m);
+    setAdjustPoints("");
+    setAdjustNote("");
+    setAdjustDir("credit");
+    setDetailLoading(true);
+    try {
+      const { member, history } = await getCustomerLoyaltyForPartner(m.userId);
+      if (member) setDetailMember(member);
+      setHistory(history);
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to load customer history");
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const refreshDetail = async (userId: string) => {
+    const { member, history } = await getCustomerLoyaltyForPartner(userId);
+    if (member) setDetailMember(member);
+    setHistory(history);
+  };
+
+  const handleAdjust = async () => {
+    if (!detailMember) return;
+    const pts = parseInt(adjustPoints, 10);
+    if (!Number.isFinite(pts) || pts <= 0) {
+      toast.error("Enter a positive number of points");
+      return;
+    }
+    setAdjusting(true);
+    try {
+      const res = await adminAdjustLoyalty({
+        userId: detailMember.userId,
+        points: pts,
+        direction: adjustDir,
+        note: adjustNote.trim(),
+      });
+      if (!res.ok) {
+        toast.error(res.message || "Could not adjust points");
+      } else {
+        toast.success(`${adjustDir === "credit" ? "Added" : "Removed"} ${pts} points`);
+        setAdjustPoints("");
+        setAdjustNote("");
+        await refreshDetail(detailMember.userId);
+        loadList(search.trim());
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error("Could not adjust points");
+    } finally {
+      setAdjusting(false);
+    }
+  };
+
+  if (!enabled) {
+    return (
+      <div className="max-w-md mx-auto text-center py-16">
+        <Gift className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+        <h2 className="text-lg font-semibold">Loyalty points aren&apos;t enabled</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Ask support to enable the loyalty feature, then turn it on under Settings → Features.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5 animate-in fade-in duration-300">
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight flex items-center gap-2">
+          <Gift className="h-6 w-6 text-orange-600" />
+          Loyalty
+        </h1>
+        <p className="text-muted-foreground">Points your customers have earned and redeemed.</p>
+      </div>
+
+      {/* Summary */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {loading && !summary ? (
+          Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-[88px] rounded-xl" />)
+        ) : (
+          <>
+            <StatCard icon={Users} label="Members" value={(summary?.members ?? 0).toLocaleString()} />
+            <StatCard
+              icon={Coins}
+              label="Outstanding"
+              value={`${(summary?.outstandingPoints ?? 0).toLocaleString()} pts`}
+              sub={`${currency}${(summary?.outstandingValue ?? 0).toLocaleString()} liability`}
+            />
+            <StatCard icon={TrendingUp} label="Issued (lifetime)" value={`${(summary?.lifetimeIssued ?? 0).toLocaleString()} pts`} />
+            <StatCard icon={TrendingDown} label="Redeemed (lifetime)" value={`${(summary?.lifetimeRedeemed ?? 0).toLocaleString()} pts`} />
+          </>
+        )}
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search customers by name or phone"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {/* Member list */}
+      <Card>
+        <CardContent className="p-0 divide-y">
+          {loading ? (
+            Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="p-4">
+                <Skeleton className="h-5 w-40" />
+              </div>
+            ))
+          ) : members.length === 0 ? (
+            <div className="text-center py-14 text-muted-foreground">
+              <Users className="h-8 w-8 mx-auto mb-2 opacity-50" />
+              {search ? "No customers match your search." : "No loyalty members yet."}
+            </div>
+          ) : (
+            members.map((m) => (
+              <button
+                key={m.userId}
+                onClick={() => openDetail(m)}
+                className="w-full flex items-center gap-3 p-4 text-left hover:bg-muted/50 transition-colors"
+              >
+                <div className="h-10 w-10 rounded-full bg-orange-100 text-orange-700 flex items-center justify-center font-semibold shrink-0">
+                  {(m.name || "?").charAt(0).toUpperCase()}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium truncate flex items-center gap-1.5">
+                    {m.name}
+                    {m.flagged && <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">{m.phone || "—"}</div>
+                </div>
+                <div className="text-right shrink-0">
+                  <div className="font-bold">{m.balance.toLocaleString()} pts</div>
+                  <div className="text-xs text-muted-foreground">{currency}{Math.round(m.balance)} value</div>
+                </div>
+                <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+              </button>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Customer detail drawer */}
+      <Sheet open={!!selected} onOpenChange={(o) => !o && setSelected(null)}>
+        <SheetContent side="right" className="w-full sm:max-w-md p-0 flex flex-col">
+          <SheetHeader className="p-5 pb-3 border-b">
+            <SheetTitle className="flex items-center gap-2">
+              <Gift className="h-5 w-5 text-orange-600" />
+              {detailMember?.name || "Customer"}
+            </SheetTitle>
+          </SheetHeader>
+
+          {detailMember && (
+            <div className="flex-1 overflow-y-auto">
+              {/* Balance hero */}
+              <div className="m-5 rounded-2xl bg-gradient-to-br from-orange-500 to-orange-600 text-white p-5">
+                <div className="text-orange-50 text-sm">Current balance</div>
+                <div className="text-4xl font-extrabold mt-1">{detailMember.balance.toLocaleString()}</div>
+                <div className="text-orange-50 text-sm">points · worth {currency}{Math.round(detailMember.balance)}</div>
+                <div className="flex gap-4 mt-4 text-xs text-orange-50">
+                  <div>Earned <span className="font-semibold text-white">{detailMember.lifetimeEarned}</span></div>
+                  <div>Redeemed <span className="font-semibold text-white">{detailMember.lifetimeRedeemed}</span></div>
+                  <div>{detailMember.phone}</div>
+                </div>
+              </div>
+
+              {detailMember.flagged && (
+                <div className="mx-5 mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 flex items-center gap-2">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  This account failed an integrity check and is locked. Contact support.
+                </div>
+              )}
+
+              {/* Manual adjust */}
+              <div className="mx-5 mb-4 rounded-xl border p-4">
+                <div className="font-semibold text-sm mb-3">Adjust points</div>
+                <div className="grid grid-cols-2 gap-2 mb-3">
+                  <button
+                    onClick={() => setAdjustDir("credit")}
+                    className={`flex items-center justify-center gap-1.5 rounded-lg py-2 text-sm font-medium border transition-colors ${
+                      adjustDir === "credit" ? "bg-emerald-50 border-emerald-300 text-emerald-700" : "border-border text-muted-foreground"
+                    }`}
+                  >
+                    <Plus className="h-4 w-4" /> Add
+                  </button>
+                  <button
+                    onClick={() => setAdjustDir("debit")}
+                    className={`flex items-center justify-center gap-1.5 rounded-lg py-2 text-sm font-medium border transition-colors ${
+                      adjustDir === "debit" ? "bg-orange-50 border-orange-300 text-orange-700" : "border-border text-muted-foreground"
+                    }`}
+                  >
+                    <Minus className="h-4 w-4" /> Remove
+                  </button>
+                </div>
+                <Input
+                  type="number"
+                  min={1}
+                  placeholder="Points"
+                  value={adjustPoints}
+                  onChange={(e) => setAdjustPoints(e.target.value)}
+                  className="mb-2"
+                />
+                <Input
+                  placeholder="Reason (shown to customer)"
+                  value={adjustNote}
+                  onChange={(e) => setAdjustNote(e.target.value)}
+                  className="mb-3"
+                  maxLength={280}
+                />
+                <Button onClick={handleAdjust} disabled={adjusting} className="w-full bg-orange-600 hover:bg-orange-700">
+                  {adjusting ? <Loader2 className="h-4 w-4 animate-spin" /> : adjustDir === "credit" ? "Add points" : "Remove points"}
+                </Button>
+              </div>
+
+              {/* History */}
+              <div className="mx-5 mb-6">
+                <div className="font-semibold text-sm mb-1">Transaction history</div>
+                {detailLoading ? (
+                  <div className="py-6 text-center text-muted-foreground"><Loader2 className="h-5 w-5 animate-spin mx-auto" /></div>
+                ) : history.length === 0 ? (
+                  <div className="py-6 text-center text-sm text-muted-foreground">No transactions yet.</div>
+                ) : (
+                  <div className="divide-y">
+                    {history.map((t) => (
+                      <TxnRow key={t.id} txn={t} currency={currency} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/src/components/admin-v2/AdminV2Settings.tsx
+++ b/src/components/admin-v2/AdminV2Settings.tsx
@@ -14,6 +14,7 @@ import { SlotBookingSettings } from "./settings/SlotBookingSettings";
 import { OrderTypesSettings } from "./settings/OrderTypesSettings";
 import { BrandingSettings } from "./settings/BrandingSettings";
 import { IntegrationsSettings } from "./settings/IntegrationsSettings";
+import { LoyaltyPointsSettings } from "./settings/LoyaltyPointsSettings";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -26,6 +27,7 @@ import {
     Palette,
     SlidersHorizontal,
     Plug,
+    Gift,
 } from "lucide-react";
 import { useAuthStore } from "@/store/authStore";
 import { useAdminSettingsStore } from "@/store/adminSettingsStore";
@@ -76,6 +78,7 @@ export function AdminV2Settings() {
     const showDiscountSettings = features?.ordering?.access || features?.delivery?.access;
     const showPrebookingGroup = features?.prebooking?.access && features?.prebooking?.enabled;
     const showStorefront = features?.storefront?.access && features?.storefront?.enabled;
+    const showLoyalty = features?.loyalty_points?.access;
 
     const username = (userData as any)?.username;
     const firstQrCodeId = (userData as any)?.qr_codes?.[0]?.id;
@@ -146,6 +149,15 @@ export function AdminV2Settings() {
             desc: "Google Business, WhatsApp & delivery platforms",
             icon: Plug,
             sections: [{ key: "integrations", label: "Integrations", Component: IntegrationsSettings }],
+        },
+        {
+            key: "loyalty",
+            label: "Loyalty",
+            desc: "Points customers earn & redeem at your store",
+            icon: Gift,
+            sections: showLoyalty
+                ? [{ key: "loyalty-points", label: "Loyalty Points", Component: LoyaltyPointsSettings }]
+                : [],
         },
         {
             key: "features",

--- a/src/components/admin-v2/OrderDetails.tsx
+++ b/src/components/admin-v2/OrderDetails.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/select";
 import useOrderStore from "@/store/orderStore";
 import { useOrderSubscriptionStore } from "@/store/orderSubscriptionStore";
+import { getOrderLoyaltyInfo } from "@/app/actions/loyalty";
 import { toast } from "sonner";
 import { Printer, Edit, MapPin, Phone, MessageCircle } from "lucide-react";
 
@@ -197,6 +198,17 @@ export function OrderDetails({ order, onBack, onEdit }: OrderDetailsProps) {
     const [passwordModalOpen, setPasswordModalOpen] = React.useState(false);
     const [pendingAction, setPendingAction] = React.useState<(() => void) | null>(null);
     const [cancelOpen, setCancelOpen] = React.useState(false);
+    const [loyaltyInfo, setLoyaltyInfo] = React.useState<{ pointsRedeemed: number; redeemValue: number; pointsEarned: number | null } | null>(null);
+
+    React.useEffect(() => {
+        const id = order?.id;
+        if (!id) return;
+        let cancelled = false;
+        getOrderLoyaltyInfo(id)
+            .then((info) => { if (!cancelled) setLoyaltyInfo(info); })
+            .catch(() => { });
+        return () => { cancelled = true; };
+    }, [order?.id]);
 
     if (!order) return null;
 
@@ -899,13 +911,35 @@ export function OrderDetails({ order, onBack, onEdit }: OrderDetailsProps) {
                             </TableRow>
                         )}
 
-                        {/* Total Amount */}
+                        {/* Loyalty points redeemed */}
+                        {loyaltyInfo && loyaltyInfo.pointsRedeemed > 0 && (
+                            <TableRow className="bg-orange-50 font-medium text-orange-700">
+                                <TableCell colSpan={3} className="text-right text-sm">
+                                    Loyalty Points Redeemed ({loyaltyInfo.pointsRedeemed} pts)
+                                </TableCell>
+                                <TableCell className="text-right text-sm text-orange-700">
+                                    - {currency}{loyaltyInfo.redeemValue.toFixed(2)}
+                                </TableCell>
+                            </TableRow>
+                        )}
+
+                        {/* Total Amount (balance payable after points) */}
                         <TableRow className="bg-muted/50 font-bold text-lg border-t-2">
-                            <TableCell colSpan={3} className="text-right">Total Amount</TableCell>
+                            <TableCell colSpan={3} className="text-right">
+                                {loyaltyInfo && loyaltyInfo.pointsRedeemed > 0 ? "Balance Payable" : "Total Amount"}
+                            </TableCell>
                             <TableCell className="text-right">
                                 {currency}{grandTotal.toFixed(2)}
                             </TableCell>
                         </TableRow>
+
+                        {loyaltyInfo && loyaltyInfo.pointsEarned != null && loyaltyInfo.pointsEarned > 0 && (
+                            <TableRow>
+                                <TableCell colSpan={4} className="text-right text-xs text-emerald-600 pt-2">
+                                    Customer earned {loyaltyInfo.pointsEarned} loyalty points on this order
+                                </TableCell>
+                            </TableRow>
+                        )}
                     </TableBody>
                 </Table>
             </div>

--- a/src/components/admin-v2/settings/FeatureSettings.tsx
+++ b/src/components/admin-v2/settings/FeatureSettings.tsx
@@ -353,6 +353,23 @@ export function FeatureSettings() {
                                     />
                                 </div>
                             )}
+
+                            {features.loyalty_points?.access && (
+                                <div className="flex items-center justify-between p-4 border rounded-lg">
+                                    <div className="space-y-0.5">
+                                        <div className="font-medium">Loyalty Points</div>
+                                        <div className="text-sm text-muted-foreground">
+                                            {features.loyalty_points.enabled
+                                                ? "Enabled — customers earn & redeem points. Configure earn rate in Loyalty settings."
+                                                : "Disabled — no points are earned or redeemable"}
+                                        </div>
+                                    </div>
+                                    <Switch
+                                        checked={features.loyalty_points.enabled}
+                                        onCheckedChange={(checked) => handleFeatureToggle("loyalty_points", checked)}
+                                    />
+                                </div>
+                            )}
                         </>
                     )}
                 </CardContent>

--- a/src/components/admin-v2/settings/LoyaltyPointsSettings.tsx
+++ b/src/components/admin-v2/settings/LoyaltyPointsSettings.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuthStore } from "@/store/authStore";
+import { toast } from "sonner";
+import { updatePartner } from "@/api/partners";
+import { revalidateTag } from "@/app/actions/revalidate";
+import { Gift, Percent, Coins, Wallet } from "lucide-react";
+import { getFeatures } from "@/lib/getFeatures";
+import { useAdminSettingsStore } from "@/store/adminSettingsStore";
+import {
+    DEFAULT_LOYALTY_SETTINGS,
+    parseLoyaltySettings,
+    serializeLoyaltySettings,
+    computeEarnPoints,
+    pointsToValue,
+    type LoyaltySettings,
+} from "@/lib/loyalty/config";
+
+export function LoyaltyPointsSettings() {
+    const { userData, setState } = useAuthStore();
+    const { setSaveAction, setHasChanges } = useAdminSettingsStore();
+
+    const [cfg, setCfg] = useState<LoyaltySettings>(DEFAULT_LOYALTY_SETTINGS);
+    const [initialLoaded, setInitialLoaded] = useState(false);
+
+    const currency = (userData as any)?.currency || "₹";
+    const enabled = !!getFeatures((userData as any)?.feature_flags || null).loyalty_points?.enabled;
+
+    useEffect(() => {
+        if (!userData) return;
+        setCfg(parseLoyaltySettings((userData as any)?.loyalty_settings));
+        setInitialLoaded(true);
+    }, [userData]);
+
+    const handleSave = useCallback(async () => {
+        if (!userData) return;
+        try {
+            const payload = serializeLoyaltySettings(cfg);
+            await updatePartner((userData as any).id, { loyalty_settings: payload });
+            revalidateTag((userData as any).id);
+            setState({ loyalty_settings: payload } as any);
+            toast.success("Loyalty settings saved");
+            setHasChanges(false);
+        } catch (e) {
+            console.error("Error saving loyalty settings:", e);
+            toast.error("Failed to save loyalty settings");
+        }
+    }, [cfg, userData, setState, setHasChanges]);
+
+    useEffect(() => {
+        if (!initialLoaded) return;
+        setHasChanges(true);
+        setSaveAction(handleSave);
+        return () => {
+            setSaveAction(null);
+            setHasChanges(false);
+        };
+    }, [cfg, initialLoaded, handleSave, setSaveAction, setHasChanges]);
+
+    const example = useMemo(() => {
+        const sample = 500;
+        const pts = computeEarnPoints(sample, cfg);
+        return { sample, pts, value: pointsToValue(pts, cfg) };
+    }, [cfg]);
+
+    const num = (v: string) => (v === "" ? 0 : Math.max(0, parseFloat(v) || 0));
+
+    if (!userData) return null;
+
+    return (
+        <div className="space-y-4">
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <Gift className="h-5 w-5 text-orange-600" />
+                        Loyalty Points
+                    </CardTitle>
+                    <CardDescription>
+                        Customers earn points on completed orders and redeem them on future orders at
+                        your store only. 1 point = {currency}1.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-5">
+                    {!enabled && (
+                        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+                            Loyalty points are currently <span className="font-semibold">off</span>. Turn
+                            them on under <span className="font-semibold">Settings → Features</span> to
+                            start awarding points. You can still configure the rules below.
+                        </div>
+                    )}
+
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="space-y-1.5">
+                            <Label htmlFor="earn_percent" className="flex items-center gap-1.5">
+                                <Percent className="h-3.5 w-3.5 text-muted-foreground" />
+                                Earn rate (% of order)
+                            </Label>
+                            <Input
+                                id="earn_percent"
+                                type="number"
+                                inputMode="decimal"
+                                min={0}
+                                max={100}
+                                step="0.5"
+                                value={cfg.earn_percent}
+                                onChange={(e) => setCfg((p) => ({ ...p, earn_percent: Math.min(100, num(e.target.value)) }))}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Points awarded after an order is completed.
+                            </p>
+                        </div>
+
+                        <div className="space-y-1.5">
+                            <Label htmlFor="min_order_amount" className="flex items-center gap-1.5">
+                                <Coins className="h-3.5 w-3.5 text-muted-foreground" />
+                                Min order to earn ({currency})
+                            </Label>
+                            <Input
+                                id="min_order_amount"
+                                type="number"
+                                inputMode="decimal"
+                                min={0}
+                                step="1"
+                                value={cfg.min_order_amount}
+                                onChange={(e) => setCfg((p) => ({ ...p, min_order_amount: num(e.target.value) }))}
+                            />
+                            <p className="text-xs text-muted-foreground">Orders below this earn nothing.</p>
+                        </div>
+
+                        <div className="space-y-1.5">
+                            <Label htmlFor="max_redeem_percent" className="flex items-center gap-1.5">
+                                <Wallet className="h-3.5 w-3.5 text-muted-foreground" />
+                                Max redeemable (% of bill)
+                            </Label>
+                            <Input
+                                id="max_redeem_percent"
+                                type="number"
+                                inputMode="decimal"
+                                min={0}
+                                max={100}
+                                step="5"
+                                value={cfg.max_redeem_percent}
+                                onChange={(e) => setCfg((p) => ({ ...p, max_redeem_percent: Math.min(100, num(e.target.value)) }))}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Cap on how much of an order points can cover.
+                            </p>
+                        </div>
+
+                        <div className="space-y-1.5">
+                            <Label htmlFor="min_redeem_points">Min points to redeem</Label>
+                            <Input
+                                id="min_redeem_points"
+                                type="number"
+                                inputMode="numeric"
+                                min={0}
+                                step="1"
+                                value={cfg.min_redeem_points}
+                                onChange={(e) => setCfg((p) => ({ ...p, min_redeem_points: Math.round(num(e.target.value)) }))}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Customers need at least this many points to redeem.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="rounded-xl bg-orange-50 border border-orange-100 px-4 py-3">
+                        <div className="text-sm text-orange-900">
+                            <span className="font-semibold">Example:</span> a {currency}
+                            {example.sample.toLocaleString()} order earns{" "}
+                            <span className="font-semibold">{example.pts} points</span>
+                            {example.pts > 0 ? (
+                                <>
+                                    {" "}worth{" "}
+                                    <span className="font-semibold">
+                                        {currency}
+                                        {example.value}
+                                    </span>{" "}
+                                    on their next visit.
+                                </>
+                            ) : (
+                                <> — increase the earn rate or lower the minimum order.</>
+                            )}
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/components/hotelDetail/placeOrder/LoyaltyRedeemCard.tsx
+++ b/src/components/hotelDetail/placeOrder/LoyaltyRedeemCard.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Coins, Check } from "lucide-react";
+
+interface LoyaltyRedeemCardProps {
+  currency: string;
+  /** Customer's available points balance at this partner. */
+  balance: number;
+  /** ₹ value of one point. */
+  pointValue: number;
+  /** Max points applicable to this order (bounded by balance + bill cap). */
+  maxPoints: number;
+  /** Minimum points needed to redeem. */
+  minRedeemPoints: number;
+  /** Currently-applied points. */
+  points: number;
+  /** ₹ discount of the applied points. */
+  value: number;
+  onChange: (points: number) => void;
+  /** Optional: open the full points history. */
+  onViewHistory?: () => void;
+}
+
+/**
+ * Customer-facing "use loyalty points" control on the checkout sheet. Mobile-app
+ * styled (chunky toggle row + slider), and inherits the modal's --pom-* theme vars
+ * so it sits naturally above the bill. Parent owns the points state and the
+ * authoritative server redemption — this is purely presentational.
+ */
+export function LoyaltyRedeemCard({
+  currency,
+  balance,
+  pointValue,
+  maxPoints,
+  minRedeemPoints,
+  points,
+  value,
+  onChange,
+  onViewHistory,
+}: LoyaltyRedeemCardProps) {
+  if (!balance || balance <= 0) return null;
+
+  const canRedeem = maxPoints >= Math.max(1, minRedeemPoints);
+  const applied = points > 0;
+
+  return (
+    <div
+      className="rounded-2xl border p-4"
+      style={{
+        borderColor: applied ? "var(--pom-accent, #ea580c)" : "var(--pom-card-border, #e7e5e4)",
+        background: applied ? "rgba(234,88,12,0.04)" : "var(--pom-card-bg, #fff)",
+      }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div
+            className="h-10 w-10 rounded-full flex items-center justify-center shrink-0"
+            style={{ background: "rgba(234,88,12,0.12)", color: "var(--pom-accent, #ea580c)" }}
+          >
+            <Coins className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="font-semibold text-inherit text-[15px] leading-tight">Loyalty Points</div>
+            <div className="text-xs" style={{ color: "var(--pom-text-muted)" }}>
+              You have <span className="font-semibold">{balance.toLocaleString()}</span> pts
+              {" "}({currency}
+              {Math.round(balance * pointValue)})
+            </div>
+            {onViewHistory && (
+              <button
+                type="button"
+                onClick={onViewHistory}
+                className="text-xs font-medium mt-0.5 underline-offset-2 hover:underline"
+                style={{ color: "var(--pom-accent, #ea580c)" }}
+              >
+                View history
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Toggle: apply max ⇄ clear */}
+        <button
+          type="button"
+          disabled={!canRedeem}
+          onClick={() => onChange(applied ? 0 : maxPoints)}
+          aria-pressed={applied}
+          className="relative inline-flex h-7 w-12 items-center rounded-full transition-colors disabled:opacity-40 shrink-0"
+          style={{ background: applied ? "var(--pom-accent, #ea580c)" : "#d6d3d1" }}
+        >
+          <span
+            className={`inline-block h-6 w-6 transform rounded-full bg-white shadow transition-transform ${
+              applied ? "translate-x-[22px]" : "translate-x-0.5"
+            }`}
+          />
+        </button>
+      </div>
+
+      {!canRedeem && (
+        <div className="mt-3 text-xs" style={{ color: "var(--pom-text-muted)" }}>
+          {balance < minRedeemPoints
+            ? `Earn at least ${minRedeemPoints} points to start redeeming.`
+            : "Points can't be applied to this order."}
+        </div>
+      )}
+
+      {applied && (
+        <div className="mt-4 space-y-3">
+          <input
+            type="range"
+            min={0}
+            max={maxPoints}
+            step={1}
+            value={points}
+            onChange={(e) => onChange(Number(e.target.value))}
+            className="w-full accent-orange-600"
+            style={{ accentColor: "var(--pom-accent, #ea580c)" }}
+            aria-label="Points to redeem"
+          />
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 text-sm font-medium text-inherit">
+              <Check className="h-4 w-4" style={{ color: "var(--pom-accent, #ea580c)" }} />
+              Using {points.toLocaleString()} pts
+            </div>
+            <div className="text-sm font-bold" style={{ color: "var(--pom-accent, #ea580c)" }}>
+              − {currency}
+              {value.toFixed(2)}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/hotelDetail/placeOrder/PlaceOrderModal.tsx
+++ b/src/components/hotelDetail/placeOrder/PlaceOrderModal.tsx
@@ -49,6 +49,10 @@ import { load as loadCashfree } from "@cashfreepayments/cashfree-js";
 import CashfreeEmbedModal from "@/components/CashfreeEmbedModal";
 import { waitForCashfreeContainer } from "@/lib/cashfreeEmbed";
 import { finalizeCfOrder } from "@/app/actions/cfOrders";
+import { LoyaltyRedeemCard } from "./LoyaltyRedeemCard";
+import { LoyaltyHistorySheet } from "@/components/loyalty/LoyaltyPointsBadge";
+import { getLoyaltyRedeemContext, redeemLoyaltyPoints, refundLoyaltyForOrder } from "@/app/actions/loyalty";
+import { computeMaxRedeemable } from "@/lib/loyalty/config";
 import { isWithinTimeWindow } from "@/lib/isWithinTimeWindow";
 import { checkDeliveryAgentAvailability } from "@/app/actions/deliveryAgent";
 import { quoteDeliveryFare } from "@/app/actions/porterBridge";
@@ -607,6 +611,8 @@ interface BillCardProps {
   } | null;
   porterQuoteLoading?: boolean;
   usePorterForCharge?: boolean;
+  /** ₹ value of loyalty points the customer is redeeming on this order. */
+  loyaltyRedeemValue?: number;
 }
 
 const BillCard = ({
@@ -624,6 +630,7 @@ const BillCard = ({
   porterQuote,
   porterQuoteLoading,
   usePorterForCharge,
+  loyaltyRedeemValue = 0,
 }: BillCardProps) => {
   const subtotal = items.reduce(
     (acc, item) => acc + item.price * item.quantity,
@@ -702,7 +709,8 @@ const BillCard = ({
     }
     discountSavings = Math.min(discountSavings, subtotal);
   }
-  const grandTotal = Math.max(0, subtotal + qrExtraCharges + deliveryCharges + parcelCharge + gstAmount - discountSavings);
+  const loyaltyApplied = Math.max(0, Math.min(loyaltyRedeemValue, subtotal + qrExtraCharges + deliveryCharges + parcelCharge + gstAmount - discountSavings));
+  const grandTotal = Math.max(0, subtotal + qrExtraCharges + deliveryCharges + parcelCharge + gstAmount - discountSavings - loyaltyApplied);
 
   return (
     <div>
@@ -824,6 +832,15 @@ const BillCard = ({
             </span>
             <span style={{ color: "var(--pom-accent, #ea580c)" }}>
               -{currency}{" "}{discountSavings.toFixed(2)}
+            </span>
+          </div>
+        )}
+
+        {loyaltyApplied > 0 && (
+          <div className="flex justify-between text-sm opacity-80">
+            <span className="font-medium">Loyalty Points</span>
+            <span style={{ color: "var(--pom-accent, #ea580c)" }}>
+              -{currency}{" "}{loyaltyApplied.toFixed(2)}
             </span>
           </div>
         )}
@@ -1689,6 +1706,34 @@ const PlaceOrderModal = ({
   const [finalOrderAmount, setFinalOrderAmount] = useState(0);
   const [generatedWhatsappLink, setGeneratedWhatsappLink] = useState<string>("");
   const [cashfreePaid, setCashfreePaid] = useState(hasCashfreeReturn);
+
+  // Loyalty points: context (balance + rules) fetched server-side, and how many
+  // points the customer chose to redeem on this order. The actual debit/correction
+  // is done server-side after the order is created (see handlePlaceOrder / cashfree).
+  const [loyaltyCtx, setLoyaltyCtx] = useState<{
+    enabled: boolean;
+    balance: number;
+    pointValue: number;
+    minRedeemPoints: number;
+    maxRedeemPercent: number;
+  } | null>(null);
+  const [redeemPoints, setRedeemPoints] = useState(0);
+  const [loyaltyHistoryOpen, setLoyaltyHistoryOpen] = useState(false);
+
+  // Load the customer's loyalty standing for this partner when the sheet opens.
+  useEffect(() => {
+    if (!open_place_order_modal || !(user as any)?.id || !hotelData?.id) return;
+    let cancelled = false;
+    getLoyaltyRedeemContext(hotelData.id)
+      .then((ctx) => { if (!cancelled) setLoyaltyCtx(ctx); })
+      .catch(() => { if (!cancelled) setLoyaltyCtx(null); });
+    return () => { cancelled = true; };
+  }, [open_place_order_modal, (user as any)?.id, hotelData?.id]);
+
+  // Clear any points selection whenever the sheet closes.
+  useEffect(() => {
+    if (!open_place_order_modal) setRedeemPoints(0);
+  }, [open_place_order_modal]);
 
   // Customer name state
   const needUserName = hotelData?.delivery_rules?.need_user_name ?? false;
@@ -2823,12 +2868,25 @@ const PlaceOrderModal = ({
       if (result) {
         if (result.id) {
           localStorage?.setItem("last-order-id", result.id);
+
+          // Redeem loyalty points server-side now that the order exists. The server
+          // re-validates the balance, writes the signed debit, and corrects the order
+          // total — so the bill the customer pays reflects the points used.
+          if (redeemPoints > 0 && loyaltyCtx?.enabled) {
+            try {
+              const r = await redeemLoyaltyPoints({ orderId: result.id, points: redeemPoints });
+              if (r.ok && r.value > 0) setFinalOrderAmount(r.orderTotal);
+            } catch (e) {
+              console.warn("[loyalty] redeem failed", e);
+            }
+          }
         }
 
         if (appliedDiscount?.id) {
           fetchFromHasura(incrementDiscountUsageMutation, { id: appliedDiscount.id }).catch(() => { });
         }
 
+        setRedeemPoints(0);
         setAppliedDiscount(null);
         setDiscountInput("");
         setDiscountError("");
@@ -2989,12 +3047,26 @@ const PlaceOrderModal = ({
       }
       const orderId = placed.id;
 
+      // Redeem loyalty points BEFORE locking the Cashfree amount. The server writes
+      // the signed debit and returns the corrected order total, which becomes the
+      // exact amount charged. If payment later fails/abandons, points are refunded
+      // (failure paths below + the pending-order expiry cron).
+      let payable = grandTotal;
+      if (redeemPoints > 0 && loyaltyCtx?.enabled) {
+        try {
+          const r = await redeemLoyaltyPoints({ orderId, points: redeemPoints });
+          if (r.ok && r.value > 0) payable = r.orderTotal;
+        } catch (e) {
+          console.warn("[loyalty] redeem failed", e);
+        }
+      }
+
       // Store order context in sessionStorage so we can resume after redirect
       sessionStorage.setItem("cashfree_pending_order", JSON.stringify({
         cfOrderId,
         orderId,
         partnerId: hotelData.id,
-        amount: grandTotal,
+        amount: payable,
         orderType: orderType || null,
         address: address || null,
         customerName: customerName || null,
@@ -3011,7 +3083,7 @@ const PlaceOrderModal = ({
       const cfRes = await createCashfreeOrderForPartner(
         hotelData.id,
         cfOrderId,
-        Math.round(grandTotal * 100) / 100,
+        Math.round(payable * 100) / 100,
         {
           id: user.id,
           name: (user as any)?.full_name || customerName || "Customer",
@@ -3022,6 +3094,7 @@ const PlaceOrderModal = ({
       );
 
       if (!cfRes.success) {
+        if (redeemPoints > 0) refundLoyaltyForOrder(orderId, "Payment could not be started").catch(() => {});
         toast.error(`Payment failed: ${cfRes.error || "could not create payment order"}`, { duration: 30000 });
         setOrderStatus("idle");
         return;
@@ -3063,6 +3136,7 @@ const PlaceOrderModal = ({
 
       if (result?.error) {
         console.error("Cashfree error:", result.error);
+        if (redeemPoints > 0) refundLoyaltyForOrder(orderId, "Payment failed").catch(() => {});
         const full =
           typeof result.error === "string"
             ? result.error
@@ -3276,6 +3350,23 @@ const PlaceOrderModal = ({
   );
   const _barDiscountSavings = appliedDiscount ? computeDiscountSavings(appliedDiscount) : 0;
   const _barGrandTotal = Math.max(0, _barSubtotal + _barQrCharge + _barDeliveryCharge + _barParcelCharge + _barGst - _barDiscountSavings);
+
+  // ---- Loyalty redemption (derived) ----
+  // `_barGrandTotal` is the pre-redemption total. Max points are bounded by the
+  // balance and the partner's bill cap; the value is subtracted to get what's payable.
+  const loyaltyPointValue = loyaltyCtx?.pointValue && loyaltyCtx.pointValue > 0 ? loyaltyCtx.pointValue : 1;
+  const loyaltyMaxPoints = loyaltyCtx?.enabled
+    ? computeMaxRedeemable(_barGrandTotal, loyaltyCtx.balance, {
+        earn_percent: 0,
+        min_order_amount: 0,
+        max_redeem_percent: loyaltyCtx.maxRedeemPercent,
+        min_redeem_points: loyaltyCtx.minRedeemPoints,
+        point_value: loyaltyPointValue,
+      })
+    : 0;
+  const effectiveRedeemPoints = Math.max(0, Math.min(redeemPoints, loyaltyMaxPoints));
+  const loyaltyRedeemValue = Math.round(effectiveRedeemPoints * loyaltyPointValue * 100) / 100;
+  const payableTotal = Math.max(0, Math.round((_barGrandTotal - loyaltyRedeemValue) * 100) / 100);
 
   return (
     <>
@@ -3600,8 +3691,33 @@ const PlaceOrderModal = ({
                   porterQuote={porterQuote}
                   porterQuoteLoading={porterQuoteLoading}
                   usePorterForCharge={usePorterForCharge}
+                  loyaltyRedeemValue={loyaltyRedeemValue}
                 />
               </div>
+
+              {/* Loyalty points redemption */}
+              {user && loyaltyCtx?.enabled && loyaltyCtx.balance > 0 && (
+                <LoyaltyRedeemCard
+                  currency={hotelData?.currency || "₹"}
+                  balance={loyaltyCtx.balance}
+                  pointValue={loyaltyPointValue}
+                  maxPoints={loyaltyMaxPoints}
+                  minRedeemPoints={loyaltyCtx.minRedeemPoints}
+                  points={effectiveRedeemPoints}
+                  value={loyaltyRedeemValue}
+                  onChange={(p) => setRedeemPoints(Math.max(0, Math.min(p, loyaltyMaxPoints)))}
+                  onViewHistory={() => setLoyaltyHistoryOpen(true)}
+                />
+              )}
+              {user && loyaltyCtx?.enabled && (
+                <LoyaltyHistorySheet
+                  partnerId={hotelData.id}
+                  currency={hotelData?.currency || "₹"}
+                  storeName={hotelData?.store_name}
+                  open={loyaltyHistoryOpen}
+                  onOpenChange={setLoyaltyHistoryOpen}
+                />
+              )}
 
               {/* Login prompt */}
               {!user && (
@@ -3792,7 +3908,7 @@ const PlaceOrderModal = ({
                     ) : (
                       <>
                         <span className="text-left shrink-0">
-                          <span className="block text-[14px] font-bold leading-tight">{hotelData?.currency || "₹"}{_barGrandTotal.toFixed(2)}</span>
+                          <span className="block text-[14px] font-bold leading-tight">{hotelData?.currency || "₹"}{payableTotal.toFixed(2)}</span>
                           <span className="block text-[10px] font-semibold opacity-80 leading-tight">TOTAL</span>
                         </span>
                         <span className="flex items-center gap-1 text-[14px] font-bold whitespace-nowrap">

--- a/src/components/hotelDetail/placeOrder/PlaceOrderModalV2.tsx
+++ b/src/components/hotelDetail/placeOrder/PlaceOrderModalV2.tsx
@@ -58,6 +58,10 @@ import { load as loadCashfree } from "@cashfreepayments/cashfree-js";
 import CashfreeEmbedModal from "@/components/CashfreeEmbedModal";
 import { waitForCashfreeContainer } from "@/lib/cashfreeEmbed";
 import { finalizeCfOrder } from "@/app/actions/cfOrders";
+import { LoyaltyRedeemCard } from "./LoyaltyRedeemCard";
+import { LoyaltyHistorySheet } from "@/components/loyalty/LoyaltyPointsBadge";
+import { getLoyaltyRedeemContext, redeemLoyaltyPoints, refundLoyaltyForOrder } from "@/app/actions/loyalty";
+import { computeMaxRedeemable } from "@/lib/loyalty/config";
 
 type AppliedDiscount = {
   id: string;
@@ -182,6 +186,18 @@ const PlaceOrderModalV2 = ({
   const [discountInput, setDiscountInput] = useState("");
   const [discountError, setDiscountError] = useState("");
   const [validatingCode, setValidatingCode] = useState(false);
+
+  // Loyalty points state (mirrors PlaceOrderModal). Redemption is finalized
+  // server-side after the order exists; this only drives the UI + the requested amount.
+  const [loyaltyCtx, setLoyaltyCtx] = useState<{
+    enabled: boolean;
+    balance: number;
+    pointValue: number;
+    minRedeemPoints: number;
+    maxRedeemPercent: number;
+  } | null>(null);
+  const [redeemPoints, setRedeemPoints] = useState(0);
+  const [loyaltyHistoryOpen, setLoyaltyHistoryOpen] = useState(false);
 
   // Address management state
   const [showAddressSheet, setShowAddressSheet] = useState(false);
@@ -561,6 +577,37 @@ const PlaceOrderModalV2 = ({
 
   const extraChargesTotal = deliveryCharge + parcelCharge + qrExtraCharge;
   const grandTotal = Math.max(0, subtotal + extraChargesTotal + additionalGst - discountSavings);
+
+  // ---- Loyalty redemption (derived) ----
+  // grandTotal is the pre-redemption total; payableTotal is what the customer pays.
+  const loyaltyPointValue = loyaltyCtx?.pointValue && loyaltyCtx.pointValue > 0 ? loyaltyCtx.pointValue : 1;
+  const loyaltyMaxPoints = loyaltyCtx?.enabled
+    ? computeMaxRedeemable(grandTotal, loyaltyCtx.balance, {
+        earn_percent: 0,
+        min_order_amount: 0,
+        max_redeem_percent: loyaltyCtx.maxRedeemPercent,
+        min_redeem_points: loyaltyCtx.minRedeemPoints,
+        point_value: loyaltyPointValue,
+      })
+    : 0;
+  const effectiveRedeemPoints = Math.max(0, Math.min(redeemPoints, loyaltyMaxPoints));
+  const loyaltyRedeemValue = Math.round(effectiveRedeemPoints * loyaltyPointValue * 100) / 100;
+  const payableTotal = Math.max(0, Math.round((grandTotal - loyaltyRedeemValue) * 100) / 100);
+
+  // Load the customer's loyalty standing for this partner when the sheet opens.
+  useEffect(() => {
+    if (!open_place_order_modal || !(user as any)?.id || !hotelData?.id) return;
+    let cancelled = false;
+    getLoyaltyRedeemContext(hotelData.id)
+      .then((ctx) => { if (!cancelled) setLoyaltyCtx(ctx); })
+      .catch(() => { if (!cancelled) setLoyaltyCtx(null); });
+    return () => { cancelled = true; };
+  }, [open_place_order_modal, (user as any)?.id, hotelData?.id]);
+
+  // Clear points selection when the sheet closes.
+  useEffect(() => {
+    if (!open_place_order_modal) setRedeemPoints(0);
+  }, [open_place_order_modal]);
 
   // Fetch available coupon discounts
   useEffect(() => {
@@ -1031,7 +1078,7 @@ const PlaceOrderModalV2 = ({
         setPlacedOrderId(pending.orderId);
       }
 
-      setSavedOrderTotal(grandTotal);
+      setSavedOrderTotal((pending as any).amount ?? grandTotal);
       // Payment done — clear the cart now (it was kept through the pending phase
       // so the customer could retry if payment failed).
       try {
@@ -1207,13 +1254,24 @@ const PlaceOrderModalV2 = ({
       }
       const orderId = placed.id;
 
+      // Redeem loyalty points BEFORE locking the Cashfree amount; charge the corrected total.
+      let payable = grandTotal;
+      if (redeemPoints > 0 && loyaltyCtx?.enabled) {
+        try {
+          const r = await redeemLoyaltyPoints({ orderId, points: redeemPoints });
+          if (r.ok && r.value > 0) payable = r.orderTotal;
+        } catch (e) {
+          console.warn("[loyalty] redeem failed", e);
+        }
+      }
+
       sessionStorage.setItem(
         "cashfree_pending_order",
         JSON.stringify({
           cfOrderId,
           orderId,
           partnerId: hotelData.id,
-          amount: grandTotal,
+          amount: payable,
           orderType: orderType || null,
           address: address || null,
           orderNote: orderNote || null,
@@ -1227,7 +1285,7 @@ const PlaceOrderModalV2 = ({
       const cfRes = await createCashfreeOrderForPartner(
         hotelData.id,
         cfOrderId,
-        Math.round(grandTotal * 100) / 100,
+        Math.round(payable * 100) / 100,
         {
           id: user.id,
           name: (user as any)?.full_name || "Customer",
@@ -1238,6 +1296,7 @@ const PlaceOrderModalV2 = ({
       );
 
       if (!cfRes.success) {
+        if (redeemPoints > 0) refundLoyaltyForOrder(orderId, "Payment could not be started").catch(() => {});
         toast.error(`Payment failed: ${cfRes.error || "could not create payment order"}`, { duration: 30000 });
         setOrderStatus("idle");
         sessionStorage.removeItem("cashfree_pending_order");
@@ -1277,6 +1336,7 @@ const PlaceOrderModalV2 = ({
 
       if (result?.error) {
         console.error("Cashfree error:", result.error);
+        if (redeemPoints > 0) refundLoyaltyForOrder(orderId, "Payment failed").catch(() => {});
         const full =
           typeof result.error === "string"
             ? result.error
@@ -1403,7 +1463,7 @@ const PlaceOrderModalV2 = ({
       return;
     }
 
-    setSavedOrderTotal(grandTotal);
+    setSavedOrderTotal(payableTotal);
     setOrderStatus("placing");
     try {
       const extraCharges: { name: string; amount: number; charge_type: string }[] = [];
@@ -1449,10 +1509,21 @@ const PlaceOrderModalV2 = ({
         if (result.id) {
           localStorage?.setItem("last-order-id", result.id);
           setPlacedOrderId(result.id);
+
+          // Redeem loyalty points server-side (validates balance, writes signed debit,
+          // corrects the order total). COD: no charge to reconcile.
+          if (redeemPoints > 0 && loyaltyCtx?.enabled) {
+            try {
+              await redeemLoyaltyPoints({ orderId: result.id, points: redeemPoints });
+            } catch (e) {
+              console.warn("[loyalty] redeem failed", e);
+            }
+          }
         }
         if (appliedDiscount?.id) {
           fetchFromHasura(incrementDiscountUsageMutation, { id: appliedDiscount.id }).catch(() => {});
         }
+        setRedeemPoints(0);
         setAppliedDiscount(null);
         setDiscountInput("");
         setDiscountError("");
@@ -2065,6 +2136,30 @@ const PlaceOrderModalV2 = ({
               )}
             </div>
 
+            {/* Loyalty points */}
+            {user && loyaltyCtx?.enabled && loyaltyCtx.balance > 0 && (
+              <LoyaltyRedeemCard
+                currency={currency}
+                balance={loyaltyCtx.balance}
+                pointValue={loyaltyPointValue}
+                maxPoints={loyaltyMaxPoints}
+                minRedeemPoints={loyaltyCtx.minRedeemPoints}
+                points={effectiveRedeemPoints}
+                value={loyaltyRedeemValue}
+                onChange={(p) => setRedeemPoints(Math.max(0, Math.min(p, loyaltyMaxPoints)))}
+                onViewHistory={() => setLoyaltyHistoryOpen(true)}
+              />
+            )}
+            {user && loyaltyCtx?.enabled && (
+              <LoyaltyHistorySheet
+                partnerId={hotelData.id}
+                currency={currency}
+                storeName={hotelData?.store_name}
+                open={loyaltyHistoryOpen}
+                onOpenChange={setLoyaltyHistoryOpen}
+              />
+            )}
+
             {/* To Pay Breakdown */}
             <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
               <button
@@ -2080,7 +2175,7 @@ const PlaceOrderModalV2 = ({
                 </div>
                 <div className="flex-1 text-left text-sm font-bold text-gray-900">
                   To Pay {currency}
-                  {grandTotal.toFixed(0)}
+                  {payableTotal.toFixed(0)}
                 </div>
                 {showBreakdown ? (
                   <ChevronUp className="h-5 w-5 text-gray-400" />
@@ -2188,12 +2283,19 @@ const PlaceOrderModalV2 = ({
                   {additionalGst > 0 && (
                     <Row label="GST & Other Charges" value={`${currency}${additionalGst.toFixed(0)}`} />
                   )}
+                  {loyaltyRedeemValue > 0 && (
+                    <Row
+                      label={`Loyalty Points (${effectiveRedeemPoints} pts)`}
+                      value={`-${currency}${loyaltyRedeemValue.toFixed(0)}`}
+                      accent={accent}
+                    />
+                  )}
                   <div className="border-t border-dashed border-gray-200 pt-2" />
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-bold text-gray-900">To Pay</span>
                     <span className="text-sm font-bold text-gray-900">
                       {currency}
-                      {grandTotal.toFixed(0)}
+                      {payableTotal.toFixed(0)}
                     </span>
                   </div>
                 </div>
@@ -2263,7 +2365,7 @@ const PlaceOrderModalV2 = ({
             style={{ backgroundColor: accent }}
           >
             {paymentMethod === "online" ? (
-              `Pay ${currency}${grandTotal.toFixed(0)}`
+              `Pay ${currency}${payableTotal.toFixed(0)}`
             ) : (
               "Place Order"
             )}

--- a/src/components/hotelDetail/styles/V3/V3.tsx
+++ b/src/components/hotelDetail/styles/V3/V3.tsx
@@ -25,6 +25,7 @@ import { updateUserAddressesMutation } from "@/api/auth";
 import { toast } from "sonner";
 import { useLocationStore } from "@/store/geolocationStore";
 import PullToRefresh from "@/components/PullToRefresh";
+import { LoyaltyPointsBadge } from "@/components/loyalty/LoyaltyPointsBadge";
 
 const V3 = ({
   styles,
@@ -309,6 +310,11 @@ const V3 = ({
                   logout / from the router cache. */}
               {(authUser as any)?.role === "user" && (
                 <>
+                  <LoyaltyPointsBadge
+                    partnerId={(hoteldata as any)?.id}
+                    currency={(hoteldata as any)?.currency || "₹"}
+                    storeName={(hoteldata as any)?.store_name}
+                  />
                   <Link
                     href="/user-profile"
                     className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-gray-100 transition"

--- a/src/components/loyalty/LoyaltyPointsBadge.tsx
+++ b/src/components/loyalty/LoyaltyPointsBadge.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Coins, Gift, ArrowDownLeft, ArrowUpRight, RotateCcw, Loader2 } from "lucide-react";
+import { getLoyaltyBalance, getLoyaltyHistory } from "@/app/actions/loyalty";
+import {
+  loyaltyTxnLabel,
+  type LoyaltyBalanceView,
+  type LoyaltyTxnView,
+  type LoyaltyTxnType,
+} from "@/lib/loyalty/config";
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleString(undefined, { day: "numeric", month: "short", year: "numeric", hour: "numeric", minute: "2-digit" });
+
+function txnIcon(type: LoyaltyTxnType) {
+  switch (type) {
+    case "earn":
+    case "adjust_credit":
+      return ArrowDownLeft;
+    case "redeem":
+    case "adjust_debit":
+      return ArrowUpRight;
+    case "refund":
+      return RotateCcw;
+    default:
+      return Coins;
+  }
+}
+
+/**
+ * Customer-facing partner-scoped loyalty history. Mobile-app styled bottom sheet:
+ * a points "card" hero + an earn/redeem transaction feed with running balance.
+ * Controlled — render via <LoyaltyPointsBadge> or drive `open` yourself.
+ */
+export function LoyaltyHistorySheet({
+  partnerId,
+  currency = "₹",
+  storeName,
+  open,
+  onOpenChange,
+}: {
+  partnerId: string;
+  currency?: string;
+  storeName?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [balance, setBalance] = useState<LoyaltyBalanceView | null>(null);
+  const [history, setHistory] = useState<LoyaltyTxnView[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !partnerId) return;
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([getLoyaltyBalance(partnerId), getLoyaltyHistory(partnerId, 50)])
+      .then(([b, h]) => {
+        if (cancelled) return;
+        setBalance(b);
+        setHistory(h);
+      })
+      .catch(() => {})
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [open, partnerId]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="rounded-t-3xl p-0 max-h-[85vh] flex flex-col border-0"
+      >
+        <SheetHeader className="px-5 pt-5 pb-2">
+          <SheetTitle className="flex items-center gap-2 text-left">
+            <Gift className="h-5 w-5 text-orange-600" />
+            {storeName ? `${storeName} Rewards` : "Loyalty Points"}
+          </SheetTitle>
+        </SheetHeader>
+
+        {/* Points card */}
+        <div className="px-5">
+          <div className="rounded-3xl bg-gradient-to-br from-orange-500 via-orange-500 to-amber-500 text-white p-5 shadow-lg">
+            <div className="flex items-center gap-1.5 text-orange-50 text-sm">
+              <Coins className="h-4 w-4" /> Available points
+            </div>
+            <div className="text-5xl font-extrabold mt-1 tracking-tight">
+              {loading && !balance ? "—" : (balance?.balance ?? 0).toLocaleString()}
+            </div>
+            <div className="text-orange-50 text-sm mt-0.5">
+              worth {currency}
+              {Math.round((balance?.balance ?? 0) * (balance?.pointValue ?? 1))} here
+            </div>
+            <div className="flex gap-5 mt-4 pt-3 border-t border-white/20 text-xs">
+              <div>
+                <div className="text-orange-100">Earned</div>
+                <div className="font-bold text-base">{balance?.lifetimeEarned ?? 0}</div>
+              </div>
+              <div>
+                <div className="text-orange-100">Redeemed</div>
+                <div className="font-bold text-base">{balance?.lifetimeRedeemed ?? 0}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* History */}
+        <div className="px-5 pt-5 pb-2 text-sm font-semibold text-muted-foreground">History</div>
+        <div className="flex-1 overflow-y-auto px-5 pb-8">
+          {loading ? (
+            <div className="py-10 text-center text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+            </div>
+          ) : history.length === 0 ? (
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              No points activity yet. Order to start earning!
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {history.map((t) => {
+                const Icon = txnIcon(t.type);
+                const credit = t.delta > 0;
+                return (
+                  <div key={t.id} className="flex items-center gap-3 py-3 border-b last:border-0">
+                    <div
+                      className={`h-10 w-10 rounded-full flex items-center justify-center shrink-0 ${
+                        credit ? "bg-emerald-50 text-emerald-600" : "bg-orange-50 text-orange-600"
+                      }`}
+                    >
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-sm">{loyaltyTxnLabel(t.type)}</div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {fmtDate(t.createdAt)}
+                        {t.orderDisplayId ? ` · #${t.orderDisplayId}` : ""}
+                        {t.note ? ` · ${t.note}` : ""}
+                      </div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className={`font-bold text-sm ${credit ? "text-emerald-600" : "text-orange-600"}`}>
+                        {credit ? "+" : ""}
+                        {t.delta}
+                      </div>
+                      <div className="text-[11px] text-muted-foreground">bal {t.balanceAfter}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/**
+ * Compact tappable points pill for a logged-in customer on a partner page. Self-fetches
+ * the balance and renders nothing if loyalty isn't enabled for the partner (or the user
+ * isn't a logged-in customer). Opens the history sheet on tap.
+ */
+export function LoyaltyPointsBadge({
+  partnerId,
+  currency = "₹",
+  storeName,
+  className,
+}: {
+  partnerId: string;
+  currency?: string;
+  storeName?: string;
+  className?: string;
+}) {
+  const [view, setView] = useState<LoyaltyBalanceView | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const load = useCallback(() => {
+    if (!partnerId) return;
+    getLoyaltyBalance(partnerId)
+      .then(setView)
+      .catch(() => setView(null));
+  }, [partnerId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Refresh when the sheet closes (balance may have changed after a redemption).
+  useEffect(() => {
+    if (!open) load();
+  }, [open, load]);
+
+  if (!view || !view.enabled) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={
+          className ??
+          "inline-flex items-center gap-1.5 rounded-full bg-orange-100 text-orange-700 px-3 py-1.5 text-sm font-semibold shadow-sm active:scale-95 transition-transform"
+        }
+        aria-label="View loyalty points"
+      >
+        <Coins className="h-4 w-4" />
+        {view.balance.toLocaleString()} pts
+      </button>
+      <LoyaltyHistorySheet
+        partnerId={partnerId}
+        currency={currency}
+        storeName={storeName}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}

--- a/src/components/loyalty/LoyaltyPointsBadge.tsx
+++ b/src/components/loyalty/LoyaltyPointsBadge.tsx
@@ -72,7 +72,8 @@ export function LoyaltyHistorySheet({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className="rounded-t-3xl p-0 max-h-[85vh] flex flex-col border-0"
+        className="rounded-t-3xl p-0 max-h-[85vh] flex flex-col border-0 z-[1000]"
+        overlayClassName="z-[1000]"
       >
         <SheetHeader className="px-5 pt-5 pb-2">
           <SheetTitle className="flex items-center gap-2 text-left">

--- a/src/lib/getFeatures.ts
+++ b/src/lib/getFeatures.ts
@@ -88,6 +88,18 @@ export type FeatureFlags = {
     access: boolean;
     enabled: boolean;
   };
+  /**
+   * Partner-scoped loyalty points. Customers earn a configurable % of each
+   * completed order's total as points (1 point = ₹1 by default) and redeem them
+   * against future orders at the same partner only. Earn rate, caps and minimums
+   * live in the admin-v2 Loyalty settings (`partners.loyalty_settings`); the
+   * balance/ledger is a signed, tamper-evident server-side store. `enabled` gates
+   * earning, redemption UI, and the admin loyalty surfaces.
+   */
+  loyalty_points: {
+    access: boolean;
+    enabled: boolean;
+  };
 };
 
 export const revertFeatureToString = (features: FeatureFlags): string => {
@@ -151,6 +163,10 @@ export const revertFeatureToString = (features: FeatureFlags): string => {
 
   if (features.prebooking.access) {
     parts.push(`prebooking-${features.prebooking.enabled}`);
+  }
+
+  if (features.loyalty_points.access) {
+    parts.push(`loyalty_points-${features.loyalty_points.enabled}`);
   }
 
   return parts.join(",");
@@ -218,6 +234,10 @@ export const getFeatures = (perm: string | null) => {
       access: false,
       enabled: false,
     },
+    loyalty_points: {
+      access: false,
+      enabled: false,
+    },
   };
 
   if (!perm) {
@@ -275,6 +295,9 @@ export const getFeatures = (perm: string | null) => {
       } else if (key === "prebooking") {
         permissions.prebooking.access = true;
         permissions.prebooking.enabled = value === "true";
+      } else if (key === "loyalty_points") {
+        permissions.loyalty_points.access = true;
+        permissions.loyalty_points.enabled = value === "true";
       }
     }
   }

--- a/src/lib/hasuraServerClient.ts
+++ b/src/lib/hasuraServerClient.ts
@@ -1,0 +1,56 @@
+import { GraphQLClient } from "graphql-request";
+
+/**
+ * Server-only Hasura client.
+ *
+ * Unlike `src/lib/hasuraClient.ts` (which ships `NEXT_PUBLIC_HASURA_GRAPHQL_ADMIN_SECRET`
+ * to the browser), this module reads `HASURA_SERVER_ADMIN_SECRET` — a non-public
+ * env var that Next.js never inlines into client bundles. It must only be imported
+ * from server code ("use server" actions, route handlers). The runtime guard below
+ * hard-fails if it is ever evaluated in a browser context.
+ *
+ * This is the reference data path for the staged migration off the browser-exposed
+ * admin secret (see feature_readme/loyalty-points.md → "Security").
+ */
+
+if (typeof window !== "undefined") {
+  throw new Error(
+    "hasuraServerClient must never be imported into client-side code — it would leak the server-only admin secret."
+  );
+}
+
+const endpoint =
+  process.env.HASURA_SERVER_GRAPHQL_ENDPOINT ||
+  process.env.NEXT_PUBLIC_HASURA_GRAPHQL_ENDPOINT ||
+  "";
+
+const secret =
+  process.env.HASURA_SERVER_ADMIN_SECRET ||
+  process.env.HASURA_GRAPHQL_ADMIN_SECRET ||
+  "";
+
+let _client: GraphQLClient | null = null;
+
+function getClient(): GraphQLClient {
+  if (!endpoint) {
+    throw new Error(
+      "Hasura endpoint not configured (HASURA_SERVER_GRAPHQL_ENDPOINT / NEXT_PUBLIC_HASURA_GRAPHQL_ENDPOINT)."
+    );
+  }
+  if (!secret) {
+    throw new Error("HASURA_SERVER_ADMIN_SECRET is not configured (server-only).");
+  }
+  if (!_client) {
+    _client = new GraphQLClient(endpoint, {
+      headers: { "x-hasura-admin-secret": secret },
+    });
+  }
+  return _client;
+}
+
+export async function fetchFromHasuraServer(
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<any> {
+  return getClient().request(query, variables);
+}

--- a/src/lib/loyalty/config.ts
+++ b/src/lib/loyalty/config.ts
@@ -1,0 +1,183 @@
+/**
+ * Loyalty configuration + pure math helpers.
+ *
+ * CLIENT-SAFE: this module contains no secrets and no node crypto, so it can be
+ * imported from both client components (settings form, checkout) and server
+ * actions. All ledger signing lives in the server-only `./ledger` module.
+ *
+ * Money model (locked for this build): 1 point = ₹`point_value` (default ₹1).
+ * Earning is `earn_percent`% of the order total, floored to whole points.
+ */
+
+export type LoyaltyTxnType =
+  | "earn"
+  | "redeem"
+  | "refund"
+  | "adjust_credit"
+  | "adjust_debit";
+
+/** Signed sign of the balance delta implied by each transaction type. */
+export const DELTA_SIGN: Record<LoyaltyTxnType, 1 | -1> = {
+  earn: 1,
+  refund: 1,
+  adjust_credit: 1,
+  redeem: -1,
+  adjust_debit: -1,
+};
+
+export interface LoyaltySettings {
+  /** % of the order total awarded as points on completion (1 point = ₹point_value). */
+  earn_percent: number;
+  /** Minimum order total (₹) required to earn any points. */
+  min_order_amount: number;
+  /** Max % of an order's bill that may be paid with points. */
+  max_redeem_percent: number;
+  /** Minimum points a customer must spend to redeem on an order. */
+  min_redeem_points: number;
+  /** ₹ value of one point. Fixed at 1 in this build but kept configurable internally. */
+  point_value: number;
+}
+
+export const DEFAULT_LOYALTY_SETTINGS: LoyaltySettings = {
+  earn_percent: 2,
+  min_order_amount: 0,
+  max_redeem_percent: 100,
+  min_redeem_points: 1,
+  point_value: 1,
+};
+
+function clampNum(v: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof v === "number" ? v : parseFloat(String(v));
+  if (!isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+/** Parse the partner's `loyalty_settings` JSON column into a fully-populated config. */
+export function parseLoyaltySettings(raw: string | null | undefined): LoyaltySettings {
+  if (!raw) return { ...DEFAULT_LOYALTY_SETTINGS };
+  try {
+    const o = typeof raw === "string" ? JSON.parse(raw) : (raw as any);
+    return {
+      earn_percent: clampNum(o.earn_percent, 0, 100, DEFAULT_LOYALTY_SETTINGS.earn_percent),
+      min_order_amount: clampNum(o.min_order_amount, 0, 1e9, DEFAULT_LOYALTY_SETTINGS.min_order_amount),
+      max_redeem_percent: clampNum(o.max_redeem_percent, 0, 100, DEFAULT_LOYALTY_SETTINGS.max_redeem_percent),
+      min_redeem_points: Math.round(clampNum(o.min_redeem_points, 0, 1e9, DEFAULT_LOYALTY_SETTINGS.min_redeem_points)),
+      point_value: clampNum(o.point_value, 0.01, 1e6, DEFAULT_LOYALTY_SETTINGS.point_value),
+    };
+  } catch {
+    return { ...DEFAULT_LOYALTY_SETTINGS };
+  }
+}
+
+export function serializeLoyaltySettings(s: LoyaltySettings): string {
+  return JSON.stringify(s);
+}
+
+/** Whole points earned for a completed order total (floored). */
+export function computeEarnPoints(orderTotal: number, s: LoyaltySettings): number {
+  if (!isFinite(orderTotal) || orderTotal <= 0) return 0;
+  if (orderTotal < s.min_order_amount) return 0;
+  const pv = s.point_value > 0 ? s.point_value : 1;
+  return Math.max(0, Math.floor((orderTotal * s.earn_percent) / 100 / pv));
+}
+
+/**
+ * Max whole points a customer can apply to one order, bounded by:
+ *  - their available balance, and
+ *  - `max_redeem_percent` of the order's pre-redemption total.
+ * Returns 0 when below `min_redeem_points` so the UI can hide the option.
+ */
+export function computeMaxRedeemable(
+  orderTotalBeforeRedeem: number,
+  balance: number,
+  s: LoyaltySettings
+): number {
+  if (balance <= 0 || !isFinite(orderTotalBeforeRedeem) || orderTotalBeforeRedeem <= 0) return 0;
+  const pv = s.point_value > 0 ? s.point_value : 1;
+  const capByBill = Math.floor((orderTotalBeforeRedeem * s.max_redeem_percent) / 100 / pv);
+  const max = Math.max(0, Math.min(Math.floor(balance), capByBill));
+  return max < s.min_redeem_points ? 0 : max;
+}
+
+/** ₹ value of a number of points. */
+export function pointsToValue(points: number, s: LoyaltySettings): number {
+  const pv = s.point_value > 0 ? s.point_value : 1;
+  const v = Math.max(0, Math.floor(points)) * pv;
+  // Round to 2 dp to avoid float dust in the payable amount.
+  return Math.round(v * 100) / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Display shapes returned by the loyalty server actions (client-safe).
+// ---------------------------------------------------------------------------
+
+/** Current customer's standing at one partner. */
+export interface LoyaltyBalanceView {
+  enabled: boolean;
+  balance: number;
+  lifetimeEarned: number;
+  lifetimeRedeemed: number;
+  pointValue: number;
+}
+
+/** One ledger entry, customer-facing. */
+export interface LoyaltyTxnView {
+  id: string;
+  type: LoyaltyTxnType;
+  delta: number;
+  balanceAfter: number;
+  createdAt: string;
+  note: string | null;
+  orderId: string | null;
+  orderDisplayId: string | null;
+}
+
+/** A customer row in the partner's loyalty admin list. */
+export interface LoyaltyMemberView {
+  userId: string;
+  name: string;
+  phone: string;
+  balance: number;
+  lifetimeEarned: number;
+  lifetimeRedeemed: number;
+  updatedAt: string;
+  flagged: boolean;
+}
+
+/** Headline numbers for the partner loyalty dashboard. */
+export interface LoyaltyPartnerSummary {
+  members: number;
+  outstandingPoints: number;
+  outstandingValue: number;
+  lifetimeIssued: number;
+  lifetimeRedeemed: number;
+}
+
+/** Result of applying points to an order (authoritative, server-computed). */
+export interface RedeemResult {
+  ok: boolean;
+  points: number;
+  value: number;
+  /** Order total after the (possibly clamped) redemption was applied. */
+  orderTotal: number;
+  newBalance: number;
+  message?: string;
+}
+
+/** Human label for a transaction type. */
+export function loyaltyTxnLabel(type: LoyaltyTxnType): string {
+  switch (type) {
+    case "earn":
+      return "Earned";
+    case "redeem":
+      return "Redeemed";
+    case "refund":
+      return "Refunded";
+    case "adjust_credit":
+      return "Added by store";
+    case "adjust_debit":
+      return "Removed by store";
+    default:
+      return type;
+  }
+}

--- a/src/lib/loyalty/ledger.ts
+++ b/src/lib/loyalty/ledger.ts
@@ -1,0 +1,153 @@
+import crypto from "crypto";
+import { DELTA_SIGN, type LoyaltyTxnType } from "./config";
+
+/**
+ * SERVER-ONLY loyalty ledger crypto.
+ *
+ * Every `loyalty_transactions` row is HMAC-SHA256 signed with `LOYALTY_LEDGER_SECRET`
+ * (a non-public env var) over its immutable fields, and chained to the previous row
+ * via `prev_hash`. Consequences:
+ *   - A row cannot be forged or edited without the secret → balances can't be inflated.
+ *   - There is no "transfer" operation, and a valid earn for one user can't be minted
+ *     for another → points are non-transferable.
+ *   - Deleting/reordering rows breaks the chain and is detectable; at worst it *reduces*
+ *     a balance (a denial), never increases one.
+ *
+ * The secret never leaves the server. This module hard-fails if imported on the client.
+ */
+
+if (typeof window !== "undefined") {
+  throw new Error("loyalty/ledger is server-only and must not be imported into client code.");
+}
+
+export const GENESIS_HASH = "GENESIS";
+export const LEDGER_VERSION = "loyalty.v1";
+
+/** The immutable, signed fields of a ledger row, in canonical order. */
+export interface SignableTxn {
+  id: string;
+  account_id: string;
+  user_id: string;
+  partner_id: string;
+  order_id: string | null;
+  type: LoyaltyTxnType;
+  /** Signed balance change: +earn/+refund/+adjust_credit, -redeem/-adjust_debit. */
+  delta: number;
+  balance_after: number;
+  seq: number;
+  prev_hash: string;
+  /** ISO timestamp generated server-side at append time (part of the signature). */
+  created_at: string;
+}
+
+export interface LedgerRow extends SignableTxn {
+  hash: string;
+}
+
+function ledgerSecret(): string {
+  const s = process.env.LOYALTY_LEDGER_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error("LOYALTY_LEDGER_SECRET is not configured (server-only, >= 16 chars).");
+  }
+  return s;
+}
+
+function canonical(t: SignableTxn): string {
+  // Fixed field order, pipe-delimited, version-prefixed. null order_id → "".
+  //
+  // created_at is intentionally NOT signed: a Postgres `timestamptz` does not
+  // round-trip byte-for-byte with the JS ISO string we write (microsecond vs
+  // millisecond, "+00:00" vs "Z"), which would make recomputed signatures
+  // diverge on read. Signing value + ordering + identity + chain is what
+  // guarantees integrity and non-transferability; the timestamp is cosmetic for
+  // this build. If point expiry is ever added, sign Date.parse(created_at) (epoch
+  // ms round-trips cleanly) rather than the raw string.
+  return [
+    LEDGER_VERSION,
+    t.id,
+    t.account_id,
+    t.user_id,
+    t.partner_id,
+    t.order_id ?? "",
+    t.type,
+    String(t.delta),
+    String(t.balance_after),
+    String(t.seq),
+    t.prev_hash,
+  ].join("|");
+}
+
+export function signTxn(t: SignableTxn): string {
+  return crypto.createHmac("sha256", ledgerSecret()).update(canonical(t)).digest("hex");
+}
+
+/** Timing-safe signature check for a single row. */
+export function verifyTxnHash(t: SignableTxn, hash: string): boolean {
+  const expected = signTxn(t);
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(hash || "", "utf8");
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/** True if `delta`'s sign matches its declared `type`. */
+export function deltaMatchesType(type: LoyaltyTxnType, delta: number): boolean {
+  if (delta === 0) return false;
+  return Math.sign(delta) === DELTA_SIGN[type];
+}
+
+export interface AccountHead {
+  balance: number;
+  last_seq: number;
+  last_hash: string;
+  last_txn_id: string | null;
+}
+
+/**
+ * O(1) integrity check used before sensitive writes (redeem / adjust). Confirms the
+ * cached account balance is backed by a genuinely-signed head transaction. Because the
+ * head's signature transitively depends on the whole chain via prev_hash, forging a
+ * head that matches a tampered balance requires the secret.
+ */
+export function verifyHead(account: AccountHead, head: LedgerRow | null): { ok: boolean; reason?: string } {
+  // Fresh account with no transactions yet.
+  if (account.last_seq === 0 || account.last_txn_id == null) {
+    if (head) return { ok: false, reason: "account claims no transactions but a head row exists" };
+    if (account.balance !== 0) return { ok: false, reason: "empty account has non-zero balance" };
+    if (account.last_hash !== GENESIS_HASH) return { ok: false, reason: "empty account head hash is not GENESIS" };
+    return { ok: true };
+  }
+  if (!head) return { ok: false, reason: "missing head transaction" };
+  if (head.id !== account.last_txn_id) return { ok: false, reason: "head id mismatch" };
+  if (head.seq !== account.last_seq) return { ok: false, reason: "head seq mismatch" };
+  if (head.hash !== account.last_hash) return { ok: false, reason: "head hash mismatch" };
+  if (head.balance_after !== account.balance) return { ok: false, reason: "balance does not match head balance_after" };
+  if (!deltaMatchesType(head.type, head.delta)) return { ok: false, reason: "head delta/type mismatch" };
+  if (!verifyTxnHash(head, head.hash)) return { ok: false, reason: "head signature invalid" };
+  return { ok: true };
+}
+
+/**
+ * Full chain audit. `rows` must be ascending by seq. Recomputes every signature,
+ * verifies the prev_hash chain, and folds the balance. Use for admin audits / cron.
+ */
+export function verifyChain(rows: LedgerRow[]): { ok: boolean; reason?: string; balance: number } {
+  let prev = GENESIS_HASH;
+  let bal = 0;
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    if (r.seq !== i + 1) return { ok: false, reason: `seq gap at index ${i}: got ${r.seq}, expected ${i + 1}`, balance: bal };
+    if (r.prev_hash !== prev) return { ok: false, reason: `broken chain at seq ${r.seq}`, balance: bal };
+    if (!deltaMatchesType(r.type, r.delta)) return { ok: false, reason: `delta/type mismatch at seq ${r.seq}`, balance: bal };
+    if (!verifyTxnHash(r, r.hash)) return { ok: false, reason: `bad signature at seq ${r.seq}`, balance: bal };
+    bal += r.delta;
+    if (bal < 0) return { ok: false, reason: `negative balance at seq ${r.seq}`, balance: bal };
+    if (bal !== r.balance_after) return { ok: false, reason: `balance mismatch at seq ${r.seq}`, balance: bal };
+    prev = r.hash;
+  }
+  return { ok: true, balance: bal };
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -120,6 +120,8 @@ export interface Partner extends BaseUser {
   prebooking_settings?: string | null;
   /** JSON string of OrderTypesEnabled { delivery, takeaway, dine_in }. NULL = all enabled. */
   order_types_enabled?: string | null;
+  /** JSON string of LoyaltySettings (see lib/loyalty/config.ts). Gated by the `loyalty_points` feature flag. */
+  loyalty_settings?: string | null;
   /**
    * Mobile registered on porter-bridge for this partner's delivery dispatch.
    * Read by src/app/actions/porterBridge.ts at dispatch time. Falls back to

--- a/src/store/orderStore.ts
+++ b/src/store/orderStore.ts
@@ -37,6 +37,7 @@ import {
 import { Notification } from "@/app/actions/notification";
 import { dispatchDeliveryAgent, cancelDeliveryAgent } from "@/app/actions/deliveryAgent";
 import { dispatchViaDeliveryBridge, cancelDispatch } from "@/app/actions/porterBridge";
+import { awardLoyaltyForOrder } from "@/app/actions/loyalty";
 // import { sendOrderNotification } from "@/app/actions/notification";
 
 export interface OrderItem extends HotelDataMenus {
@@ -204,6 +205,12 @@ export interface Order {
   id: string;
   items: OrderItem[];
   totalPrice: number;
+  /** Loyalty points spent on this order (0 if none). `totalPrice` already reflects the deduction. */
+  loyaltyPointsRedeemed?: number;
+  /** ₹ value of the loyalty points redeemed on this order. */
+  loyaltyRedeemValue?: number;
+  /** Loyalty points awarded for this order once completed (null until processed). */
+  loyaltyPointsEarned?: number | null;
   payment_method?: "cash" | "card" | "upi";
   createdAt: string;
   notes?: string | null;
@@ -630,6 +637,17 @@ const useOrderStore = create(
               }
               revalidateTag(userData?.id as string);
             }
+
+            // Award loyalty points for the completed order. Server-side, idempotent,
+            // re-reads the real order, and self-gates on the partner's loyalty flag —
+            // so it's safe to fire-and-forget and never blocks the status update.
+            awardLoyaltyForOrder(orderId)
+              .then((r) => {
+                if (r.ok && r.points > 0) {
+                  toast.success(`${r.points} loyalty points credited to the customer`);
+                }
+              })
+              .catch((e) => console.warn("[loyalty] award failed", e));
           }
 
           // Send order status notification to user (fire-and-forget, never block order)

--- a/src/store/posStore.ts
+++ b/src/store/posStore.ts
@@ -14,6 +14,7 @@ import {
 } from "@/api/orders";
 import { deleteBillMutation } from "@/api/pos";
 import { getNextOrderNumber, Order } from "./orderStore";
+import { awardLoyaltyForOrder } from "@/app/actions/loyalty";
 import { v4 as uuidv4 } from "uuid";
 
 
@@ -1150,6 +1151,17 @@ export const usePOSStore = create<POSState>((set, get) => ({
         }`,
         { id: orderId, status }
       );
+
+      // Award loyalty points when a POS order is completed (idempotent, server-gated).
+      if (status === "completed") {
+        awardLoyaltyForOrder(orderId)
+          .then((r) => {
+            if (r.ok && r.points > 0) {
+              toast.success(`${r.points} loyalty points credited to the customer`);
+            }
+          })
+          .catch((e) => console.warn("[loyalty] award failed", e));
+      }
 
       // Update local state
       const { pastBills, tables } = get();


### PR DESCRIPTION
## Loyalty Points

Partner-scoped customer loyalty. Customers **earn** a configurable % of every **completed** order (default **2%**, **1 point = ₹1**) and **redeem** points against future orders **at the same partner only**. Built tamper-proof from the data layer up.

### Security — "can't be tampered or transferred"
The Hasura admin secret is currently shipped to the browser, so loyalty is designed to be safe **even against an attacker who has that secret**:
- Append-only **HMAC-signed, hash-chained** `loyalty_transactions` ledger, signed with a **server-only** key (`LOYALTY_LEDGER_SECRET`). Balances can't be inflated, forged, or transferred; deletions can only *reduce* a balance (a denial) and are detectable.
- **All writes are server-only** (`src/app/actions/loyalty.ts` via `src/lib/hasuraServerClient.ts`); the client never writes loyalty tables. Balance is **verified against the signed head before every spend** — a mismatch locks the account.
- **Begins** the root-cause migration off the browser-exposed admin secret (server-only client + forward-looking role permissions on the new tables). The full app-wide migration + the forgeable-cookie fix are documented as staged, standalone work in `feature_readme/SECURITY-admin-secret-migration.md` (not bundled here — they'd break the live app / log everyone out if rushed).

### What's included
- **DB:** `loyalty_accounts` + `loyalty_transactions` (+ order/partner columns) — applied live to the `neon db` source **and** mirrored as migration + metadata files.
- **Feature flag** `loyalty_points` + **Settings → Loyalty** (earn %, min order, max redeem %, min redeem points).
- **Earn on completion** (`orderStore` + `posStore`, idempotent) + optional `/api/loyalty/award` event-trigger backstop.
- **Redeem at checkout** (COD + Cashfree) with server-authoritative total correction; **refunds** on payment failure, expiry, and cancellation.
- **Admin → Loyalty**: summary (members, outstanding ₹ liability, lifetime issued/redeemed), member search, per-customer history, **manual grant/deduct**. Redeemed points + balance-payable + earned shown on the admin order detail.
- **Customer**: mobile-app bottom-sheet points history (checkout "View history" + order page badge & earned note).

### Verified
- Live ledger integrity test **8/8** (append, chain verify, balance fold, lifetime stats, per-order idempotency, **tamper detection**, concurrency).
- All loyalty GraphQL queries validated against the live schema.
- `tsc --noEmit` **0 errors**; `next build` **succeeds**.

### ⚠️ Before deploying
Set these in the production env (server-only; **not** in the repo) or the loyalty server actions will throw:
```
HASURA_SERVER_ADMIN_SECRET=<prod admin secret>
LOYALTY_LEDGER_SECRET=<random 32-byte hex>   # permanent — rotating invalidates signatures
```
Then grant `loyalty_points-true` to a test partner's `feature_flags` to exercise it end-to-end. Full details in `feature_readme/loyalty-points.md`.

### Known follow-ups (non-blocking)
- For Petpooja partners, a COD order's POS bill shows the pre-redeem total (the customer is still charged correctly). Threading redemption into the Petpooja payload is a noted enhancement.
- Enable the optional Hasura event trigger once the prod app URL is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
