### PR TITLE
feat(storefront): brand-primary naming with optional Merchant Legal Entity Name

### DIFF
--- a/src/api/partners.ts
+++ b/src/api/partners.ts
@@ -132,6 +132,7 @@ query GetPartnerStorefrontByUsername($username: String!) {
     id
     username
     store_name
+    official_name
     store_banner
     description
     phone

--- a/src/app/[username]/about-us/page.tsx
+++ b/src/app/[username]/about-us/page.tsx
@@ -1,6 +1,11 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getLegalPartnerByUsername, getDisplayLegalName } from "@/lib/legalInfo";
+import {
+  getLegalPartnerByUsername,
+  getBrandName,
+  getLegalName,
+  hasDistinctLegalName,
+} from "@/lib/legalInfo";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
 
 const SLUG = "about-us";
@@ -13,7 +18,7 @@ export async function generateMetadata({
   const { username } = await params;
   const partner = await getLegalPartnerByUsername(username);
   if (!partner) return { title: "Not Found" };
-  const name = getDisplayLegalName(partner);
+  const name = getBrandName(partner);
   return {
     title: `About Us — ${name}`,
     description: `Learn more about ${name}.`,
@@ -30,7 +35,7 @@ export default async function AboutUsPage({
   if (!partner) notFound();
 
   const aboutText = partner.about_us?.trim();
-  const name = getDisplayLegalName(partner);
+  const name = getBrandName(partner);
 
   return (
     <LegalPageLayout partner={partner} title="About Us" currentSlug={SLUG}>
@@ -47,6 +52,11 @@ export default async function AboutUsPage({
           ingredients, and attentive service. Browse our menu to explore our
           offerings, and feel free to reach out if you would like to know
           more about us.
+        </p>
+      )}
+      {hasDistinctLegalName(partner) && (
+        <p className="mb-4 text-sm text-neutral-500">
+          {name} is a brand owned and operated by {getLegalName(partner)}.
         </p>
       )}
     </LegalPageLayout>

--- a/src/app/[username]/contact-us/page.tsx
+++ b/src/app/[username]/contact-us/page.tsx
@@ -2,12 +2,14 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
   getLegalPartnerByUsername,
-  getDisplayLegalName,
+  getBrandName,
+  getMerchantEntityName,
+  hasDistinctLegalName,
   getContactEmail,
   getContactPhone,
 } from "@/lib/legalInfo";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
-import { Mail, Phone, MapPin, Building2 } from "lucide-react";
+import { Mail, Phone, MapPin, Building2, Store } from "lucide-react";
 
 const SLUG = "contact-us";
 const LAST_UPDATED = "29 April 2026";
@@ -20,7 +22,7 @@ export async function generateMetadata({
   const { username } = await params;
   const partner = await getLegalPartnerByUsername(username);
   if (!partner) return { title: "Not Found" };
-  const name = getDisplayLegalName(partner);
+  const name = getBrandName(partner);
   return {
     title: `Contact Us — ${name}`,
     description: `Get in touch with ${name}.`,
@@ -78,7 +80,9 @@ export default async function ContactUsPage({
   const partner = await getLegalPartnerByUsername(username);
   if (!partner) notFound();
 
-  const name = getDisplayLegalName(partner);
+  const brand = getBrandName(partner);
+  const entityName = getMerchantEntityName(partner);
+  const showBrandRow = hasDistinctLegalName(partner);
   const email = getContactEmail(partner);
   const phone = getContactPhone(partner);
   const address = partner.operating_address?.trim();
@@ -96,8 +100,11 @@ export default async function ContactUsPage({
         <ContactRow
           icon={Building2}
           label="Merchant Legal Entity Name"
-          value={name}
+          value={entityName}
         />
+        {showBrandRow && (
+          <ContactRow icon={Store} label="Brand Name" value={brand} />
+        )}
         {address && (
           <ContactRow
             icon={MapPin}

--- a/src/app/[username]/home/page.tsx
+++ b/src/app/[username]/home/page.tsx
@@ -12,6 +12,7 @@ interface PartnerRow {
   id: string;
   username: string;
   store_name: string;
+  official_name?: string | null;
   store_banner?: string;
   description?: string;
   phone?: string;

--- a/src/components/admin-v2/settings/GeneralSettings.tsx
+++ b/src/components/admin-v2/settings/GeneralSettings.tsx
@@ -418,8 +418,11 @@ export function GeneralSettings() {
                     <CardContent className="space-y-4">
                         <div className="grid gap-4 sm:grid-cols-2">
                             <div className="space-y-2">
-                                <Label>Official Name (Legal Entity)</Label>
+                                <Label>Merchant Legal Entity Name</Label>
                                 <Input value={officialName} onChange={(e) => setOfficialName(e.target.value)} placeholder="e.g. Notime Services Pvt Ltd" />
+                                <p className="text-xs text-muted-foreground">
+                                    Your registered legal entity. Leave blank to show only your brand name everywhere. When set, your storefront reads &ldquo;{`{brand} (operated by {this name})`}&rdquo; on policy pages and the footer.
+                                </p>
                             </div>
                             <div className="space-y-2">
                                 <Label>Official Email ID</Label>

--- a/src/components/legal/LegalPageLayout.tsx
+++ b/src/components/legal/LegalPageLayout.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { ArrowLeft } from "lucide-react";
 import type { LegalPartnerInfo } from "@/lib/legalInfo";
-import { getDisplayLegalName } from "@/lib/legalInfo";
+import { getBrandName, getLegalName, hasDistinctLegalName } from "@/lib/legalInfo";
 
 const POLICY_LINKS = [
   { href: "about-us", label: "About Us" },
@@ -29,7 +29,9 @@ export function LegalPageLayout({
   currentSlug,
   children,
 }: Props) {
-  const displayName = getDisplayLegalName(partner);
+  const brand = getBrandName(partner);
+  const legalName = getLegalName(partner);
+  const showLegal = hasDistinctLegalName(partner);
   const username = partner.username;
   const year = new Date().getFullYear();
 
@@ -43,12 +45,12 @@ export function LegalPageLayout({
             className="flex items-center gap-2 text-sm font-medium text-neutral-700 hover:text-neutral-900"
           >
             <ArrowLeft className="h-4 w-4" />
-            <span>Back to {partner.store_name}</span>
+            <span>Back to {brand}</span>
           </Link>
           <div className="text-right">
-            <p className="text-sm font-semibold text-neutral-900">{displayName}</p>
-            {partner.official_name && partner.official_name !== partner.store_name && (
-              <p className="text-xs text-neutral-500">{partner.store_name}</p>
+            <p className="text-sm font-semibold text-neutral-900">{brand}</p>
+            {showLegal && (
+              <p className="text-xs text-neutral-500">Operated by {legalName}</p>
             )}
           </div>
         </div>
@@ -60,7 +62,7 @@ export function LegalPageLayout({
           <CardContent className="px-5 py-8 sm:px-10 sm:py-12">
             <div className="mb-6">
               <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
-                {displayName}
+                {brand}
               </p>
               <h1 className="mt-2 text-3xl font-bold tracking-tight text-neutral-900 sm:text-4xl">
                 {title}
@@ -108,7 +110,8 @@ export function LegalPageLayout({
           </nav>
           <Separator className="my-6 bg-neutral-200" />
           <p className="text-xs text-neutral-500">
-            &copy; {year} {displayName}. All rights reserved.
+            &copy; {year} {brand}. All rights reserved.
+            {showLegal && <> {brand} is a brand operated by {legalName}.</>}
           </p>
         </div>
       </footer>

--- a/src/components/legal/policyContent.tsx
+++ b/src/components/legal/policyContent.tsx
@@ -1,6 +1,9 @@
 import type { LegalPartnerInfo } from "@/lib/legalInfo";
 import {
-  getDisplayLegalName,
+  getBrandName,
+  getLegalName,
+  hasDistinctLegalName,
+  getLegalEntityPhrase,
   getContactEmail,
   getContactPhone,
   getJurisdiction,
@@ -24,14 +27,21 @@ function Section({
 }
 
 function Contact({ partner }: { partner: LegalPartnerInfo }) {
-  const name = getDisplayLegalName(partner);
+  const brand = getBrandName(partner);
+  const legalName = getLegalName(partner);
+  const showLegal = hasDistinctLegalName(partner);
   const email = getContactEmail(partner);
   const phone = getContactPhone(partner);
   const address = partner.operating_address;
 
   return (
     <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4">
-      <p className="font-medium text-neutral-900">{name}</p>
+      <p className="font-medium text-neutral-900">{brand}</p>
+      {showLegal && (
+        <p className="mt-0.5 text-sm text-neutral-600">
+          Merchant Legal Entity Name: {legalName}
+        </p>
+      )}
       {address && <p className="mt-1 text-neutral-700">{address}</p>}
       {email && (
         <p className="mt-1 text-neutral-700">
@@ -60,7 +70,7 @@ function Contact({ partner }: { partner: LegalPartnerInfo }) {
 }
 
 export function TermsContent({ partner }: { partner: LegalPartnerInfo }) {
-  const name = getDisplayLegalName(partner);
+  const entity = getLegalEntityPhrase(partner);
   const jurisdiction = getJurisdiction(partner);
   return (
     <>
@@ -68,7 +78,7 @@ export function TermsContent({ partner }: { partner: LegalPartnerInfo }) {
         <p>
           These Terms and Conditions, along with privacy policy or other terms
           (&ldquo;Terms&rdquo;) constitute a binding agreement by and between{" "}
-          {name}, (&ldquo;Website Owner&rdquo; or &ldquo;we&rdquo; or
+          {entity}, (&ldquo;Website Owner&rdquo; or &ldquo;we&rdquo; or
           &ldquo;us&rdquo; or &ldquo;our&rdquo;) and you (&ldquo;you&rdquo; or
           &ldquo;your&rdquo;) and relate to your use of our website, goods (as
           applicable) or services (as applicable) (collectively,
@@ -176,12 +186,12 @@ export function TermsContent({ partner }: { partner: LegalPartnerInfo }) {
 }
 
 export function PrivacyContent({ partner }: { partner: LegalPartnerInfo }) {
-  const name = getDisplayLegalName(partner);
+  const entity = getLegalEntityPhrase(partner);
   return (
     <>
       <Section title="1. Introduction">
         <p>
-          {name} (&ldquo;we&rdquo;, &ldquo;us&rdquo;, or &ldquo;our&rdquo;)
+          {entity} (&ldquo;we&rdquo;, &ldquo;us&rdquo;, or &ldquo;our&rdquo;)
           respects your privacy and is committed to protecting the personal
           information you share with us. This Privacy Policy explains what
           information we collect, how we use it, and the choices you have.
@@ -284,12 +294,13 @@ export function PrivacyContent({ partner }: { partner: LegalPartnerInfo }) {
 }
 
 export function RefundContent({ partner }: { partner: LegalPartnerInfo }) {
-  const name = getDisplayLegalName(partner);
+  const brand = getBrandName(partner);
+  const entity = getLegalEntityPhrase(partner);
   return (
     <>
       <Section title="Overview">
         <p>
-          {name} believes in helping its customers as far as possible, and has
+          {entity} believes in helping its customers as far as possible, and has
           therefore a liberal cancellation policy. Under this policy:
         </p>
         <ul className="ml-5 list-disc space-y-3">
@@ -301,7 +312,7 @@ export function RefundContent({ partner }: { partner: LegalPartnerInfo }) {
             process of shipping them.
           </li>
           <li>
-            {name} does not accept cancellation requests for perishable items
+            {brand} does not accept cancellation requests for perishable items
             like flowers, eatables etc. However, refund/replacement can be
             made if the customer establishes that the quality of product
             delivered is not good.
@@ -321,7 +332,7 @@ export function RefundContent({ partner }: { partner: LegalPartnerInfo }) {
           <li>
             In case of complaints regarding products that come with a
             warranty from manufacturers, please refer the issue to them. In
-            case of any Refunds approved by {name}, it will take 1&ndash;2
+            case of any Refunds approved by {brand}, it will take 1&ndash;2
             days for the refund to be processed to the end customer.
           </li>
         </ul>
@@ -339,12 +350,12 @@ export function RefundContent({ partner }: { partner: LegalPartnerInfo }) {
 }
 
 export function ShippingContent({ partner }: { partner: LegalPartnerInfo }) {
-  const name = getDisplayLegalName(partner);
+  const entity = getLegalEntityPhrase(partner);
   return (
     <>
       <Section title="1. Overview">
         <p>
-          {name} offers takeaway and (where available) delivery for orders
+          {entity} offers takeaway and (where available) delivery for orders
           placed through our website. This policy outlines our delivery and
           pickup practices.
         </p>

--- a/src/components/website/website-styles-v4.ts
+++ b/src/components/website/website-styles-v4.ts
@@ -120,6 +120,7 @@ export const WEBSITE_STYLES_V4 = `
 .wb4-foot-sublabel{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:#9A9A9A;margin-top:18px;font-weight:500}
 .wb4-foot-sublist{display:flex;flex-direction:column;gap:6px;margin-top:6px}
 .wb4-foot-bot{margin-top:48px;font-size:13px;color:#9A9A9A}
+.wb4-foot-legal{margin-top:6px;font-size:12px;color:#B5B5B5}
 
 .wb4 .wb4-watermark{position:fixed;right:18px;bottom:18px;z-index:60;background:#fff;border-radius:999px;padding:8px 14px;display:inline-flex;align-items:center;gap:6px;font-size:12.5px;color:#0c0a09;box-shadow:0 6px 18px -6px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);transition:transform .15s, box-shadow .15s}
 .wb4 .wb4-watermark:hover{transform:translateY(-1px);box-shadow:0 10px 22px -6px rgba(0,0,0,.22),0 0 0 1px rgba(0,0,0,.05);color:#0c0a09}

--- a/src/lib/legalInfo.ts
+++ b/src/lib/legalInfo.ts
@@ -28,8 +28,60 @@ export async function getLegalPartnerByUsername(
   }
 }
 
+/**
+ * Brand name — the public-facing identity (store name). This is the name shown
+ * everywhere by default. A partner always has a brand name.
+ */
+export function getBrandName(p: LegalPartnerInfo): string {
+  return (p.store_name || "").trim();
+}
+
+/**
+ * Legal entity name ("Merchant Legal Entity Name") as set in Official Settings.
+ * Returns null when the partner has not provided one — in that case only the
+ * brand name should be displayed.
+ */
+export function getLegalName(p: LegalPartnerInfo): string | null {
+  return p.official_name?.trim() || null;
+}
+
+/**
+ * True only when a legal entity name has been provided AND it is meaningfully
+ * different from the brand name. Drives whether we surface the legal entity
+ * alongside the brand (e.g. "Brand, operated by Legal Entity").
+ */
+export function hasDistinctLegalName(p: LegalPartnerInfo): boolean {
+  const legal = getLegalName(p);
+  if (!legal) return false;
+  return legal.toLowerCase() !== getBrandName(p).toLowerCase();
+}
+
+/**
+ * The value to show against a "Merchant Legal Entity Name" label. Falls back to
+ * the brand name so the field is never blank, but prefers the legal entity.
+ */
+export function getMerchantEntityName(p: LegalPartnerInfo): string {
+  return getLegalName(p) || getBrandName(p);
+}
+
+/**
+ * The phrase used for the FIRST mention of the business in a legal document.
+ *   - no distinct legal name:  "Brand"
+ *   - distinct legal name set:  "Brand (operated by Legal Entity)"
+ * Subsequent mentions should use {@link getBrandName} (or "we"/"us").
+ */
+export function getLegalEntityPhrase(p: LegalPartnerInfo): string {
+  const brand = getBrandName(p);
+  if (!hasDistinctLegalName(p)) return brand;
+  return `${brand} (operated by ${getLegalName(p)})`;
+}
+
+/**
+ * Public display name used for page titles / metadata. Always the brand name —
+ * the legal entity is reserved for the body of policy pages.
+ */
 export function getDisplayLegalName(p: LegalPartnerInfo): string {
-  return p.official_name?.trim() || p.store_name;
+  return getBrandName(p);
 }
 
 export function getContactEmail(p: LegalPartnerInfo): string | null {

--- a/src/screens/WebsitePageV4.tsx
+++ b/src/screens/WebsitePageV4.tsx
@@ -16,6 +16,7 @@ interface PartnerData {
   id: string;
   username: string;
   store_name: string;
+  official_name?: string | null;
   store_banner?: string;
   description?: string;
   phone?: string;
@@ -647,6 +648,14 @@ export default function WebsitePageV4({
             <div className="wb4-foot-bot">
               {merged.footer.copyright ||
                 `© ${new Date().getFullYear()} ${partner.store_name}`}
+              {partner.official_name?.trim() &&
+                partner.official_name.trim().toLowerCase() !==
+                  partner.store_name.trim().toLowerCase() && (
+                  <div className="wb4-foot-legal">
+                    {partner.store_name} is a brand operated by{" "}
+                    {partner.official_name.trim()}.
+                  </div>
+                )}
             </div>
           </div>
         </footer>


### PR DESCRIPTION
## What

Adds a **Merchant Legal Entity Name** concept to the partner storefront, with brand-primary display.

Previously `getDisplayLegalName` *replaced* the brand name with the legal name everywhere it was set. This inverts that to the standard professional convention:

- **Default (no legal name set):** only the brand name (`store_name`) appears on the landing page, footer, and all policy pages.
- **When a Merchant Legal Entity Name is set:** the brand stays primary, and the legal entity is surfaced alongside it — first mention reads `Brand (operated by Legal Entity)`, with "operated by …" lines in footers/headers.

## Changes

- **`src/lib/legalInfo.ts`** — new helpers: getBrandName, getLegalName, hasDistinctLegalName, getMerchantEntityName, getLegalEntityPhrase. getDisplayLegalName now returns the brand name.
- **policyContent.tsx** — first mention uses `Brand (operated by Legal Entity)`; later mentions use the brand. Contact card shows a Merchant Legal Entity Name line when distinct.
- **LegalPageLayout.tsx** — header + footer use the brand; "operated by" lines only when a legal name is set.
- **about-us / contact-us** — brand primary; contact-us shows the legal entity in its dedicated row plus a separate Brand Name row when they differ.
- **WebsitePageV4.tsx + website-styles-v4.ts** — landing footer adds a legal-entity line when set.
- **api/partners.ts + home/page.tsx** — fetch official_name in the storefront query/type.
- **GeneralSettings.tsx** — field relabeled to "Merchant Legal Entity Name" with helper text.

## DB

No migration needed — `official_name` (and related official_* columns) already exist on `partners` (verified via Hasura).

🤖 Generated with [Claude Code](https://claude.com/claude-code)